### PR TITLE
Add RACF support

### DIFF
--- a/client.go
+++ b/client.go
@@ -42,16 +42,19 @@ func (c *Client) Get(conf *client.Config, dn string) (*client.Entry, error) {
 }
 
 func (c *Client) UpdatePassword(conf *client.Config, dn string, newPassword string) error {
-	filters := map[*client.Field][]string{
-		client.FieldRegistry.ObjectClass: {"*"},
+	filters := map[*client.Field][]string{client.FieldRegistry.ObjectClass: {"*"}}
+
+	newValues, err := client.GetSchemaFieldRegistry(conf.Schema, newPassword)
+	if err != nil {
+		return fmt.Errorf("error updating password: %s", err)
 	}
-	return c.ldap.UpdatePassword(conf, dn, filters, newPassword)
+
+	return c.ldap.UpdatePassword(conf, dn, newValues, filters)
 }
 
 func (c *Client) UpdateRootPassword(conf *client.Config, newPassword string) error {
-	filters := map[*client.Field][]string{
-		client.FieldRegistry.ObjectClass: {"*"},
-	}
+	filters := map[*client.Field][]string{client.FieldRegistry.ObjectClass: {"*"}}
+	newValues := map[*client.Field][]string{client.FieldRegistry.UserPassword: {newPassword}}
 
-	return c.ldap.UpdatePassword(conf, conf.BindDN, filters, newPassword)
+	return c.ldap.UpdatePassword(conf, conf.BindDN, newValues, filters)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -15,6 +15,7 @@ type Config struct {
 	*ldaputil.ConfigEntry
 	LastBindPassword         string    `json:"last_bind_password"`
 	LastBindPasswordRotation time.Time `json:"last_bind_password_rotation"`
+	Schema                   string    `json:"schema"`
 }
 
 func New() Client {
@@ -92,10 +93,7 @@ func (c *Client) UpdateEntry(cfg *Config, baseDN string, filters map[*Field][]st
 // UpdatePassword uses a Modify call under the hood instead of LDAP change password function.
 // This allows AD and OpenLDAP secret engines to use the same api without changes to
 // the interface.
-func (c *Client) UpdatePassword(cfg *Config, baseDN string, filters map[*Field][]string, newPassword string) error {
-	newValues := map[*Field][]string{
-		FieldRegistry.UserPassword: {newPassword},
-	}
+func (c *Client) UpdatePassword(cfg *Config, baseDN string, newValues map[*Field][]string, filters map[*Field][]string) error {
 	return c.UpdateEntry(cfg, baseDN, filters, newValues)
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -126,7 +126,7 @@ func TestUpdatePasswordOpenLDAP(t *testing.T) {
 	}
 }
 
-func TestUpdatePasswordRCAF(t *testing.T) {
+func TestUpdatePasswordRACF(t *testing.T) {
 	testPass := "hell0$catz*"
 
 	config := emptyConfig()
@@ -142,8 +142,8 @@ func TestUpdatePasswordRCAF(t *testing.T) {
 	conn.ModifyRequestToExpect = &ldap.ModifyRequest{
 		DN: dn,
 	}
-	conn.ModifyRequestToExpect.Replace("rcafPassword", []string{testPass})
-	conn.ModifyRequestToExpect.Replace("rcafAttributes", []string{"noexpired"})
+	conn.ModifyRequestToExpect.Replace("racfPassword", []string{testPass})
+	conn.ModifyRequestToExpect.Replace("racfAttributes", []string{"resume"})
 
 	ldapClient := &ldaputil.Client{
 		Logger: hclog.NewNullLogger(),
@@ -156,7 +156,7 @@ func TestUpdatePasswordRCAF(t *testing.T) {
 		FieldRegistry.ObjectClass: {"*"},
 	}
 
-	newValues, err := GetSchemaFieldRegistry("rcaf", testPass)
+	newValues, err := GetSchemaFieldRegistry("racf", testPass)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -88,7 +88,7 @@ func TestUpdateEntry(t *testing.T) {
 	}
 }
 
-func TestUpdatePassword(t *testing.T) {
+func TestUpdatePasswordOpenLDAP(t *testing.T) {
 	testPass := "hell0$catz*"
 
 	config := emptyConfig()
@@ -116,7 +116,52 @@ func TestUpdatePassword(t *testing.T) {
 		FieldRegistry.ObjectClass: {"*"},
 	}
 
-	if err := client.UpdatePassword(config, dn, filters, testPass); err != nil {
+	newValues, err := GetSchemaFieldRegistry("openldap", testPass)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client.UpdatePassword(config, dn, newValues, filters); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUpdatePasswordRCAF(t *testing.T) {
+	testPass := "hell0$catz*"
+
+	config := emptyConfig()
+	config.BindDN = "cats"
+	config.BindPassword = "dogs"
+
+	conn := &ldapifc.FakeLDAPConnection{
+		SearchRequestToExpect: testSearchRequest(),
+		SearchResultToReturn:  testSearchResult(),
+	}
+
+	dn := "CN=Jim H.. Jones,OU=Vault,OU=Engineering,DC=example,DC=com"
+	conn.ModifyRequestToExpect = &ldap.ModifyRequest{
+		DN: dn,
+	}
+	conn.ModifyRequestToExpect.Replace("rcafPassword", []string{testPass})
+	conn.ModifyRequestToExpect.Replace("rcafAttributes", []string{"noexpired"})
+
+	ldapClient := &ldaputil.Client{
+		Logger: hclog.NewNullLogger(),
+		LDAP:   &ldapifc.FakeLDAPClient{conn},
+	}
+
+	client := &Client{ldapClient}
+
+	filters := map[*Field][]string{
+		FieldRegistry.ObjectClass: {"*"},
+	}
+
+	newValues, err := GetSchemaFieldRegistry("rcaf", testPass)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client.UpdatePassword(config, dn, newValues, filters); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -154,7 +199,12 @@ func TestUpdateRootPassword(t *testing.T) {
 		FieldRegistry.ObjectClass: {"*"},
 	}
 
-	if err := client.UpdatePassword(config, config.BindDN, filters, testPass); err != nil {
+	newValues, err := GetSchemaFieldRegistry("openldap", testPass)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client.UpdatePassword(config, config.BindDN, newValues, filters); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -143,7 +143,7 @@ func TestUpdatePasswordRACF(t *testing.T) {
 		DN: dn,
 	}
 	conn.ModifyRequestToExpect.Replace("racfPassword", []string{testPass})
-	conn.ModifyRequestToExpect.Replace("racfAttributes", []string{"resume"})
+	conn.ModifyRequestToExpect.Replace("racfAttributes", []string{"noexpire"})
 
 	ldapClient := &ldaputil.Client{
 		Logger: hclog.NewNullLogger(),

--- a/client/fieldregistry.go
+++ b/client/fieldregistry.go
@@ -59,8 +59,8 @@ type fieldRegistry struct {
 	ObjectSID          *Field `ldap:"objectSid"`
 	OrganizationalUnit *Field `ldap:"ou"`
 	PasswordLastSet    *Field `ldap:"passwordLastSet"`
-	RcafPassword       *Field `ldap:"rcafPassword"`
-	RcafAttributes     *Field `ldap:"rcafAttributes"`
+	RCAFPassword       *Field `ldap:"rcafPassword"`
+	RCAFAttributes     *Field `ldap:"rcafAttributes"`
 	UnicodePassword    *Field `ldap:"unicodePwd"`
 	UserPassword       *Field `ldap:"userPassword"`
 	UserPrincipalName  *Field `ldap:"userPrincipalName"`

--- a/client/fieldregistry.go
+++ b/client/fieldregistry.go
@@ -59,8 +59,8 @@ type fieldRegistry struct {
 	ObjectSID          *Field `ldap:"objectSid"`
 	OrganizationalUnit *Field `ldap:"ou"`
 	PasswordLastSet    *Field `ldap:"passwordLastSet"`
-	RCAFPassword       *Field `ldap:"rcafPassword"`
-	RCAFAttributes     *Field `ldap:"rcafAttributes"`
+	RACFPassword       *Field `ldap:"racfPassword"`
+	RACFAttributes     *Field `ldap:"racfAttributes"`
 	UnicodePassword    *Field `ldap:"unicodePwd"`
 	UserPassword       *Field `ldap:"userPassword"`
 	UserPrincipalName  *Field `ldap:"userPrincipalName"`

--- a/client/fieldregistry.go
+++ b/client/fieldregistry.go
@@ -59,6 +59,8 @@ type fieldRegistry struct {
 	ObjectSID          *Field `ldap:"objectSid"`
 	OrganizationalUnit *Field `ldap:"ou"`
 	PasswordLastSet    *Field `ldap:"passwordLastSet"`
+	RcafPassword       *Field `ldap:"rcafPassword"`
+	RcafAttributes     *Field `ldap:"rcafAttributes"`
 	UnicodePassword    *Field `ldap:"unicodePwd"`
 	UserPassword       *Field `ldap:"userPassword"`
 	UserPrincipalName  *Field `ldap:"userPrincipalName"`

--- a/client/schema.go
+++ b/client/schema.go
@@ -1,0 +1,37 @@
+package client
+
+import (
+	"fmt"
+	"github.com/hashicorp/vault/sdk/helper/strutil"
+)
+
+// SupportedSchema returns a slice of different OpenLDAP schemas supported
+// by the plugin.  This is used to change the FieldRegistry when modifying
+// user passwords.
+func SupportedSchema() []string {
+	return []string{"openldap", "rcaf"}
+}
+
+// ValidSchema checks if the configured schema is supported by the plugin.
+func ValidSchema(schema string) bool {
+	return strutil.StrListContains(SupportedSchema(), schema)
+}
+
+// GetSchemaFieldRegistry type switches field registries depending on the configured schema.
+// For example, IBM RCAF has a custom OpenLDAP schema so the password is stored in a different
+// attribute.
+func GetSchemaFieldRegistry(schema string, newPassword string) (map[*Field][]string, error) {
+	switch schema {
+	case "openldap":
+		fields := map[*Field][]string{FieldRegistry.UserPassword: {newPassword}}
+		return fields, nil
+	case "rcaf":
+		fields := map[*Field][]string{
+			FieldRegistry.RcafPassword:   {newPassword},
+			FieldRegistry.RcafAttributes: {"noexpired"},
+		}
+		return fields, nil
+	default:
+		return nil, fmt.Errorf("configured schema %s not valid", schema)
+	}
+}

--- a/client/schema.go
+++ b/client/schema.go
@@ -28,7 +28,7 @@ func GetSchemaFieldRegistry(schema string, newPassword string) (map[*Field][]str
 	case "racf":
 		fields := map[*Field][]string{
 			FieldRegistry.RACFPassword:   {newPassword},
-			FieldRegistry.RACFAttributes: {"resume"},
+			FieldRegistry.RACFAttributes: {"noexpire"},
 		}
 		return fields, nil
 	default:

--- a/client/schema.go
+++ b/client/schema.go
@@ -9,7 +9,7 @@ import (
 // by the plugin.  This is used to change the FieldRegistry when modifying
 // user passwords.
 func SupportedSchemas() []string {
-	return []string{"openldap", "rcaf"}
+	return []string{"openldap", "racf"}
 }
 
 // ValidSchema checks if the configured schema is supported by the plugin.
@@ -18,17 +18,17 @@ func ValidSchema(schema string) bool {
 }
 
 // GetSchemaFieldRegistry type switches field registries depending on the configured schema.
-// For example, IBM RCAF has a custom OpenLDAP schema so the password is stored in a different
+// For example, IBM RACF has a custom OpenLDAP schema so the password is stored in a different
 // attribute.
 func GetSchemaFieldRegistry(schema string, newPassword string) (map[*Field][]string, error) {
 	switch schema {
 	case "openldap":
 		fields := map[*Field][]string{FieldRegistry.UserPassword: {newPassword}}
 		return fields, nil
-	case "rcaf":
+	case "racf":
 		fields := map[*Field][]string{
-			FieldRegistry.RCAFPassword:   {newPassword},
-			FieldRegistry.RCAFAttributes: {"resume"},
+			FieldRegistry.RACFPassword:   {newPassword},
+			FieldRegistry.RACFAttributes: {"resume"},
 		}
 		return fields, nil
 	default:

--- a/client/schema.go
+++ b/client/schema.go
@@ -5,16 +5,16 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/strutil"
 )
 
-// SupportedSchema returns a slice of different OpenLDAP schemas supported
+// SupportedSchemas returns a slice of different OpenLDAP schemas supported
 // by the plugin.  This is used to change the FieldRegistry when modifying
 // user passwords.
-func SupportedSchema() []string {
+func SupportedSchemas() []string {
 	return []string{"openldap", "rcaf"}
 }
 
 // ValidSchema checks if the configured schema is supported by the plugin.
 func ValidSchema(schema string) bool {
-	return strutil.StrListContains(SupportedSchema(), schema)
+	return strutil.StrListContains(SupportedSchemas(), schema)
 }
 
 // GetSchemaFieldRegistry type switches field registries depending on the configured schema.
@@ -27,8 +27,8 @@ func GetSchemaFieldRegistry(schema string, newPassword string) (map[*Field][]str
 		return fields, nil
 	case "rcaf":
 		fields := map[*Field][]string{
-			FieldRegistry.RcafPassword:   {newPassword},
-			FieldRegistry.RcafAttributes: {"noexpired"},
+			FieldRegistry.RCAFPassword:   {newPassword},
+			FieldRegistry.RCAFAttributes: {"noexpired"},
 		}
 		return fields, nil
 	default:

--- a/client/schema.go
+++ b/client/schema.go
@@ -28,7 +28,7 @@ func GetSchemaFieldRegistry(schema string, newPassword string) (map[*Field][]str
 	case "rcaf":
 		fields := map[*Field][]string{
 			FieldRegistry.RCAFPassword:   {newPassword},
-			FieldRegistry.RCAFAttributes: {"noexpired"},
+			FieldRegistry.RCAFAttributes: {"resume"},
 		}
 		return fields, nil
 	default:

--- a/path_config.go
+++ b/path_config.go
@@ -3,6 +3,7 @@ package openldap
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/hashicorp/vault-plugin-secrets-openldap/client"
 	"github.com/hashicorp/vault/sdk/framework"
@@ -13,6 +14,7 @@ import (
 const (
 	configPath            = "config"
 	defaultPasswordLength = 64
+	defaultSchema         = "openldap"
 	defaultTLSVersion     = "tls12"
 )
 
@@ -71,6 +73,11 @@ func (b *backend) configFields() map[string]*framework.FieldSchema {
 		Default:     defaultPasswordLength,
 		Description: "The desired length of passwords that Vault generates.",
 	}
+	fields["schema"] = &framework.FieldSchema{
+		Type:        framework.TypeString,
+		Default:     defaultSchema,
+		Description: "The desired OpenLDAP schema used when modifying user account passwords.",
+	}
 	return fields
 }
 
@@ -92,9 +99,20 @@ func (b *backend) configCreateUpdateOperation(ctx context.Context, req *logical.
 		return nil, errors.New("url is required")
 	}
 
+	schema := fieldData.Get("schema").(string)
+	if schema == "" {
+		return nil, errors.New("schema is required")
+	}
+
+	if !client.ValidSchema(schema) {
+		return nil, fmt.Errorf("the configured schema %s is not valid.  Supported schemas: %s",
+			schema, client.SupportedSchema())
+	}
+
 	config := &config{
 		LDAP: &client.Config{
 			ConfigEntry: ldapConf,
+			Schema:      schema,
 		},
 		PasswordLength: length,
 	}

--- a/path_config.go
+++ b/path_config.go
@@ -106,7 +106,7 @@ func (b *backend) configCreateUpdateOperation(ctx context.Context, req *logical.
 
 	if !client.ValidSchema(schema) {
 		return nil, fmt.Errorf("the configured schema %s is not valid.  Supported schemas: %s",
-			schema, client.SupportedSchema())
+			schema, client.SupportedSchemas())
 	}
 
 	config := &config{


### PR DESCRIPTION
This adds schema support for IBM RCAF for managing z/OS mainframe accounts.

```bash
$ vault write openldap/config \
    binddn="cn=admin,dc=hashicorp,dc=com" \
    bindpass="admin" \
    url="ldap://0.0.0.0" \
    schema="racf" \
    length=8
Success! Data written to: openldap/config

$ vault write openldap/static-role/hashicorp \
   username='hashicorp' \
   dn='racfid=XB00000,ou=users,o=dev' \
   rotation_period="1d"
Success! Data written to: openldap/static-role/hashicorp

$ vault read openldap/static-role/hashicorp
Key                    Value
---                    -----
dn                     racfid=XB00000,ou=users,o=dev
last_vault_rotation    2020-03-03T14:02:40.594091-05:00
rotation_period        86400s
username               hashicorp

$ vault read openldap/static-cred/hashicorp
Key                    Value
---                    -----
dn                     racfid=XB00000,ou=users,o=dev
last_vault_rotation    2020-03-03T14:02:40.594091-05:00
password               n7kUe8COUdvv494lmrRQjCaYFrSuIqdn2ljYjwOmhqaEXU1a0XLHALb9fk7SPVde
rotation_period        86400s
ttl                    86400s
username               hashicorp
```