### PR TITLE
Change noexpire to noexpired

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -143,7 +143,7 @@ func TestUpdatePasswordRACF(t *testing.T) {
 		DN: dn,
 	}
 	conn.ModifyRequestToExpect.Replace("racfPassword", []string{testPass})
-	conn.ModifyRequestToExpect.Replace("racfAttributes", []string{"noexpire"})
+	conn.ModifyRequestToExpect.Replace("racfAttributes", []string{"noexpired"})
 
 	ldapClient := &ldaputil.Client{
 		Logger: hclog.NewNullLogger(),

--- a/client/schema.go
+++ b/client/schema.go
@@ -28,7 +28,7 @@ func GetSchemaFieldRegistry(schema string, newPassword string) (map[*Field][]str
 	case "racf":
 		fields := map[*Field][]string{
 			FieldRegistry.RACFPassword:   {newPassword},
-			FieldRegistry.RACFAttributes: {"noexpire"},
+			FieldRegistry.RACFAttributes: {"noexpired"},
 		}
 		return fields, nil
 	default:


### PR DESCRIPTION
Fixed a small typo in RACF attribute for `noexpired`.