### PR TITLE
Fix: Forward rotation requests from performance nodes to the primary

### DIFF
--- a/path_rotate.go
+++ b/path_rotate.go
@@ -44,10 +44,14 @@ func (b *backend) pathRotateCredentials() []*framework.Path {
 			},
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.UpdateOperation: &framework.PathOperation{
-					Callback: b.pathRotateRoleCredentialsUpdate,
+					Callback:                    b.pathRotateRoleCredentialsUpdate,
+					ForwardPerformanceStandby:   true,
+					ForwardPerformanceSecondary: true,
 				},
 				logical.CreateOperation: &framework.PathOperation{
-					Callback: b.pathRotateRoleCredentialsUpdate,
+					Callback:                    b.pathRotateRoleCredentialsUpdate,
+					ForwardPerformanceStandby:   true,
+					ForwardPerformanceSecondary: true,
 				},
 			},
 			HelpSynopsis:    pathRotateRoleCredentialsUpdateHelpSyn,

--- a/path_rotate.go
+++ b/path_rotate.go
@@ -25,10 +25,14 @@ func (b *backend) pathRotateCredentials() []*framework.Path {
 			Fields:  map[string]*framework.FieldSchema{},
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.UpdateOperation: &framework.PathOperation{
-					Callback: b.pathRotateCredentialsUpdate,
+					Callback:                    b.pathRotateCredentialsUpdate,
+					ForwardPerformanceStandby:   true,
+					ForwardPerformanceSecondary: true,
 				},
 				logical.CreateOperation: &framework.PathOperation{
-					Callback: b.pathRotateCredentialsUpdate,
+					Callback:                    b.pathRotateCredentialsUpdate,
+					ForwardPerformanceStandby:   true,
+					ForwardPerformanceSecondary: true,
 				},
 			},
 			HelpSynopsis:    pathRotateCredentialsUpdateHelpSyn,


### PR DESCRIPTION
Requests to `rotate-role` need to be forwarded from Performance Standby nodes to the Active node. We also return an error if the rotation fails, instead of silently ignoring it. This should fix an issue where calling `rotate-role/*`  appeared to succeed but actually failed, and generated messages in the logs similar to this:

> unable to rotate credentials in rotate-role: error="error writing WAL entry: cannot write to readonly storage"