### PR TITLE
Add response check to prevent panic

### DIFF
--- a/path_rotate.go
+++ b/path_rotate.go
@@ -127,7 +127,7 @@ func (b *backend) pathRotateRoleCredentialsUpdate(ctx context.Context, req *logi
 	// In create/update of static accounts, we only care if the operation
 	// err'd , and this call does not return credentials
 	item, err := b.popFromRotationQueueByKey(name)
-	if item == nil || err != nil {
+	if err != nil {
 		item = &queue.Item{
 			Key: name,
 		}
@@ -144,7 +144,7 @@ func (b *backend) pathRotateRoleCredentialsUpdate(ctx context.Context, req *logi
 		item.Priority = time.Now().Add(10 * time.Second).Unix()
 
 		// Preserve the WALID if it was returned
-		if resp.WALID != "" {
+		if resp != nil && resp.WALID != "" {
 			item.Value = resp.WALID
 		}
 	} else {

--- a/path_rotate.go
+++ b/path_rotate.go
@@ -127,7 +127,7 @@ func (b *backend) pathRotateRoleCredentialsUpdate(ctx context.Context, req *logi
 	// In create/update of static accounts, we only care if the operation
 	// err'd , and this call does not return credentials
 	item, err := b.popFromRotationQueueByKey(name)
-	if err != nil {
+	if item == nil || err != nil {
 		item = &queue.Item{
 			Key: name,
 		}


### PR DESCRIPTION
A panic occurs if `resp` is a nil pointer in the event of a password rotation failure.  Added a small check if `resp` is nil before trying to extract WAL ID from it.