### PR TITLE
Fix AD password rotation

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -166,6 +166,49 @@ func TestUpdatePasswordRACF(t *testing.T) {
 	}
 }
 
+func TestUpdatePasswordAD(t *testing.T) {
+	testPass := "hell0$catz*"
+	encodedTestPass, err := formatPassword(testPass)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config := emptyConfig()
+	config.BindDN = "cats"
+	config.BindPassword = "dogs"
+
+	conn := &ldapifc.FakeLDAPConnection{
+		SearchRequestToExpect: testSearchRequest(),
+		SearchResultToReturn:  testSearchResult(),
+	}
+
+	dn := "CN=Jim H.. Jones,OU=Vault,OU=Engineering,DC=example,DC=com"
+	conn.ModifyRequestToExpect = &ldap.ModifyRequest{
+		DN: dn,
+	}
+	conn.ModifyRequestToExpect.Replace("unicodePwd", []string{encodedTestPass})
+
+	ldapClient := &ldaputil.Client{
+		Logger: hclog.NewNullLogger(),
+		LDAP:   &ldapifc.FakeLDAPClient{conn},
+	}
+
+	client := &Client{ldapClient}
+
+	filters := map[*Field][]string{
+		FieldRegistry.ObjectClass: {"*"},
+	}
+
+	newValues, err := GetSchemaFieldRegistry("ad", testPass)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client.UpdatePassword(config, dn, newValues, filters); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // TestUpdateRootPassword mimics the UpdateRootPassword in the SecretsClient.
 // However, this test must be located within this package because when the
 // "client" is instantiated below, the "ldapClient" is being added to an

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -203,6 +203,13 @@ func TestUpdatePasswordAD(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if p, ok := newValues[FieldRegistry.UnicodePassword]; !ok {
+		t.Fatal("Expected unicodePwd field to be populated")
+	} else if len(p) != 1 {
+		t.Fatalf("Expected exactly one entry for unicodePwd but got %d", len(p))
+	} else if p[0] != encodedTestPass {
+		t.Fatalf("Expected unicodePwd field equal to %q but got %q", encodedTestPass, p[0])
+	}
 
 	if err := client.UpdatePassword(config, dn, newValues, filters); err != nil {
 		t.Fatal(err)

--- a/client/schema.go
+++ b/client/schema.go
@@ -2,14 +2,16 @@ package client
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/vault/sdk/helper/strutil"
+	"golang.org/x/text/encoding/unicode"
 )
 
 // SupportedSchemas returns a slice of different OpenLDAP schemas supported
 // by the plugin.  This is used to change the FieldRegistry when modifying
 // user passwords.
 func SupportedSchemas() []string {
-	return []string{"openldap", "racf"}
+	return []string{"openldap", "racf", "ad"}
 }
 
 // ValidSchema checks if the configured schema is supported by the plugin.
@@ -31,7 +33,20 @@ func GetSchemaFieldRegistry(schema string, newPassword string) (map[*Field][]str
 			FieldRegistry.RACFAttributes: {"noexpired"},
 		}
 		return fields, nil
+	case "ad":
+		pwdEncoded, err := formatPassword(newPassword)
+		if err != nil {
+			return nil, err
+		}
+		fields := map[*Field][]string{FieldRegistry.UnicodePassword: {pwdEncoded}}
+		return fields, nil
 	default:
 		return nil, fmt.Errorf("configured schema %s not valid", schema)
 	}
+}
+
+// According to the MS docs, the password needs to be utf16 and enclosed in quotes.
+func formatPassword(original string) (string, error) {
+	utf16 := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM)
+	return utf16.NewEncoder().String("\"" + original + "\"")
 }

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/stretchr/testify v1.4.0 // indirect
 	golang.org/x/net v0.0.0-20200519113804-d87ec0cfa476 // indirect
 	golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 // indirect
-	golang.org/x/text v0.3.2 // indirect
+	golang.org/x/text v0.3.2
 	google.golang.org/genproto v0.0.0-20200519141106-08726f379972 // indirect
 	google.golang.org/grpc v1.29.1 // indirect
 )

--- a/path_roles.go
+++ b/path_roles.go
@@ -46,7 +46,7 @@ func (b *backend) pathRoles() []*framework.Path {
 					Callback: b.pathStaticRoleRead,
 				},
 				logical.DeleteOperation: &framework.PathOperation{
-					Callback: b.pathStaticRoleDelete,
+					Callback:                    b.pathStaticRoleDelete,
 					ForwardPerformanceStandby:   true,
 					ForwardPerformanceSecondary: true,
 				},


### PR DESCRIPTION
# Overview

As reported by a customer, rotating passwords in AD using the OpenLDAP plugin didn't work, even when the same config for the AD plugin pointing at the same instance of AD did work.

This is due to the password for AD being stored in the `unicodePwd` field instead of `userPassword`, as documented [here](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/6e803168-f140-4d23-b2d3-c3a8ab5917d2). The `userPassword` field can be supported too, but it depends on some additional config on the AD server, so `unicodePwd` is the canonical field to update.

To support this, I've added a new supported schema, `"ad"`, for the OpenLDAP plugin, which must be set in the config.

# Contributor Checklist

Docs PR: https://github.com/hashicorp/vault/pull/9619
Manual testing output:

```bash
$ vault read openldap/static-cred/bob
Key                    Value
---                    -----
dn                     CN=Bob Johnson,CN=Users,dc=mycompany,dc=local
last_vault_rotation    2020-07-27T15:33:36.876161+01:00
password               opEOFFDJ1XdRBuwEt2ig2QdPcLRsoXnHpdu3rUmdZcPQlK1ym5mG1nblvbPzZkjC
rotation_period        3m
ttl                    2m43s
username               bob.johnson

ldapwhoami -h x.x.x.x -x -D "CN=Bob Johnson,CN=Users,DC=mycompany,DC=local" -w opEOFFDJ1XdRBuwEt2ig2QdPcLRsoXnHpdu3rUmdZcPQlK1ym5mG1nblvbPzZkjC
u:MYCOMPANY\bob.johnson
```

If you'd like to test this yourself, you'll need a real running instance of AD which I can help set up.

Backwards compatible: ✅ 