### PR TITLE
Backport 1.5.1: Fix AD password rotation (#16)

### DIFF
--- a/client/schema.go
+++ b/client/schema.go
@@ -2,14 +2,16 @@ package client
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/vault/sdk/helper/strutil"
+	"golang.org/x/text/encoding/unicode"
 )
 
 // SupportedSchemas returns a slice of different OpenLDAP schemas supported
 // by the plugin.  This is used to change the FieldRegistry when modifying
 // user passwords.
 func SupportedSchemas() []string {
-	return []string{"openldap", "racf"}
+	return []string{"openldap", "racf", "ad"}
 }
 
 // ValidSchema checks if the configured schema is supported by the plugin.
@@ -31,7 +33,20 @@ func GetSchemaFieldRegistry(schema string, newPassword string) (map[*Field][]str
 			FieldRegistry.RACFAttributes: {"noexpired"},
 		}
 		return fields, nil
+	case "ad":
+		pwdEncoded, err := formatPassword(newPassword)
+		if err != nil {
+			return nil, err
+		}
+		fields := map[*Field][]string{FieldRegistry.UnicodePassword: {pwdEncoded}}
+		return fields, nil
 	default:
 		return nil, fmt.Errorf("configured schema %s not valid", schema)
 	}
+}
+
+// According to the MS docs, the password needs to be utf16 and enclosed in quotes.
+func formatPassword(original string) (string, error) {
+	utf16 := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM)
+	return utf16.NewEncoder().String("\"" + original + "\"")
 }

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/stretchr/testify v1.4.0 // indirect
 	golang.org/x/net v0.0.0-20200519113804-d87ec0cfa476 // indirect
 	golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 // indirect
-	golang.org/x/text v0.3.2 // indirect
+	golang.org/x/text v0.3.2
 	google.golang.org/genproto v0.0.0-20200519141106-08726f379972 // indirect
 	google.golang.org/grpc v1.29.1 // indirect
 )

--- a/path_roles.go
+++ b/path_roles.go
@@ -46,7 +46,7 @@ func (b *backend) pathRoles() []*framework.Path {
 					Callback: b.pathStaticRoleRead,
 				},
 				logical.DeleteOperation: &framework.PathOperation{
-					Callback: b.pathStaticRoleDelete,
+					Callback:                    b.pathStaticRoleDelete,
 					ForwardPerformanceStandby:   true,
 					ForwardPerformanceSecondary: true,
 				},


### PR DESCRIPTION
This backports #16 for the vault 1.5.1 release by cherry-picking 4f49537.