### PR TITLE
A bunch of little fixes

### DIFF
--- a/path_dynamic_creds.go
+++ b/path_dynamic_creds.go
@@ -68,7 +68,7 @@ func (b *backend) pathDynamicCredsRead(ctx context.Context, req *logical.Request
 		merr := multierror.Append(fmt.Errorf("failed to create user: %w", err))
 		_, err = b.executeLDIF(config.LDAP, dRole.RollbackLDIF, templateData, true)
 		if err != nil {
-			merr = multierror.Append(fmt.Errorf("failed to roll back user creation: %w", err))
+			merr = multierror.Append(merr, fmt.Errorf("failed to roll back user creation: %w", err))
 		}
 		return nil, merr
 	}

--- a/path_dynamic_roles.go
+++ b/path_dynamic_roles.go
@@ -18,8 +18,8 @@ import (
 const (
 	secretCredsType = "creds"
 
-	dynamicRolePath = "role/"
-	dynamicCredPath = "cred/"
+	dynamicRolePath = "roles/"
+	dynamicCredPath = "creds/"
 )
 
 func (b *backend) pathDynamicRoles() []*framework.Path {

--- a/path_dynamic_roles.go
+++ b/path_dynamic_roles.go
@@ -18,7 +18,7 @@ import (
 const (
 	secretCredsType = "creds"
 
-	dynamicRolePath = "roles/"
+	dynamicRolePath = "role/"
 	dynamicCredPath = "creds/"
 )
 

--- a/path_static_roles.go
+++ b/path_static_roles.go
@@ -3,7 +3,6 @@ package openldap
 import (
 	"context"
 	"fmt"
-	"path"
 	"time"
 
 	"github.com/hashicorp/vault/sdk/framework"
@@ -19,7 +18,7 @@ const (
 func (b *backend) pathListStaticRoles() []*framework.Path {
 	return []*framework.Path{
 		{
-			Pattern: path.Join(staticRolePath, framework.OptionalParamRegex("prefix")),
+			Pattern: staticRolePath + "?$",
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ListOperation: &framework.PathOperation{
 					Callback: b.pathStaticRoleList,

--- a/scripts/acceptance-tests.bats
+++ b/scripts/acceptance-tests.bats
@@ -275,7 +275,7 @@ teardown() {
   max_ttl=20
 
   # Create role
-  run vault write openldap/role/testrole creation_ldif="${creation_ldif}" deletion_ldif="${deletion_ldif}" default_ttl="${default_ttl}s" max_ttl="${max_ttl}s"
+  run vault write openldap/role/testrole creation_ldif="${creation_ldif}" deletion_ldif="${deletion_ldif}" rollback_ldif="${deletion_ldif}" default_ttl="${default_ttl}s" max_ttl="${max_ttl}s"
   [ ${status} -eq 0 ]
 
   # Get credentials
@@ -401,6 +401,35 @@ teardown() {
     sleep 1
   done
 
+  run ldapsearch -b "${dn}" -D "${dn}" -w "${password}"
+  [ ${status} -ne 0 ]
+}
+
+@test "Dynamic Secrets - Useful error on creation failure" {
+  default_ttl=10
+  max_ttl=20
+
+  bad_creation_ldif='dn: cn={{.Username}},ou=thisgroupdoesnotexist,dc=learn,dc=example
+objectClass: person
+objectClass: top
+cn: learn
+sn: learn-{{.Username | utf16le | base64}}
+memberOf: cn=dev,ou=groups,dc=learn,dc=example
+userPassword: {{.Password}}'
+
+  # Create role
+  run vault write openldap/role/testrole creation_ldif="${bad_creation_ldif}" deletion_ldif="${deletion_ldif}" rollback_ldif="${deletion_ldif}" default_ttl="${default_ttl}s" max_ttl="${max_ttl}s"
+  [ ${status} -eq 0 ]
+
+  # Get credentials
+  run vault read -format=json openldap/cred/testrole
+  [ ${status} -ne 0 ]
+  [[ "${output}" == *"failed to create user" ]]
+
+  # Optional assertion that makes sure both errors are included but if this becomes flaky it isn't the important error and can be removed
+  [[ "${output}" == *"failed to roll back user" ]]
+
+  ## Assert the credentials do *not* work in OpenLDAP
   run ldapsearch -b "${dn}" -D "${dn}" -w "${password}"
   [ ${status} -ne 0 ]
 }

--- a/scripts/acceptance-tests.bats
+++ b/scripts/acceptance-tests.bats
@@ -183,11 +183,11 @@ teardown() {
   vault delete openldap/config
 
   # Remove any roles that were created so they don't bleed over to other tests
-  output=$(vault list -format=json openldap/role || true) # "or true" so it doesn't show an error if there are no roles
+  output=$(vault list -format=json openldap/roles || true) # "or true" so it doesn't show an error if there are no roles
 
   roles=$(echo "${output}" | jq -r .[])
   for role in ${roles}; do
-    vault delete "openldap/role/${role}" > /dev/null
+    vault delete "openldap/roles/${role}" > /dev/null
   done
 }
 
@@ -196,11 +196,11 @@ teardown() {
   max_ttl=10
 
   # Create role
-  run vault write openldap/role/testrole creation_ldif="${creation_ldif}" deletion_ldif="${deletion_ldif}" default_ttl="${default_ttl}s" max_ttl="${max_ttl}s"
+  run vault write openldap/roles/testrole creation_ldif="${creation_ldif}" deletion_ldif="${deletion_ldif}" default_ttl="${default_ttl}s" max_ttl="${max_ttl}s"
   [ ${status} -eq 0 ]
 
   # Read role and make sure it matches what we expect
-  run vault read openldap/role/testrole -format=json
+  run vault read openldap/roles/testrole -format=json
   [ ${status} -eq 0 ]
   expected='{
     "creation_ldif": "dn: cn={{.Username}},ou=users,dc=learn,dc=example\nobjectClass: person\nobjectClass: top\ncn: learn\nsn: learn-{{.Username | utf16le | base64}}\nmemberOf: cn=dev,ou=groups,dc=learn,dc=example\nuserPassword: {{.Password}}",
@@ -215,13 +215,13 @@ teardown() {
   [ "${output}" == "true" ]
 
   ## Delete the role and ensure that it and the creds endpoint isn't readable
-  run vault delete openldap/role/testrole
+  run vault delete openldap/roles/testrole
   [ ${status} -eq 0 ]
 
-  run vault read openldap/role/testrole
+  run vault read openldap/roles/testrole
   [ ${status} -ne 0 ]
 
-  run vault read openldap/cred/testrole
+  run vault read openldap/creds/testrole
   [ ${status} -ne 0 ]
 }
 
@@ -229,16 +229,16 @@ teardown() {
   # Create a bunch of roles with different prefixes
   for id in $(seq -f "%02g" 0 10); do
     rolename="testrole${id}"
-    run vault write "openldap/role/${rolename}" creation_ldif="${creation_ldif}" deletion_ldif="${deletion_ldif}" default_ttl="5s" max_ttl="10s"
+    run vault write "openldap/roles/${rolename}" creation_ldif="${creation_ldif}" deletion_ldif="${deletion_ldif}" default_ttl="5s" max_ttl="10s"
     [ ${status} -eq 0 ]
 
     rolename="roletest${id}"
-    run vault write "openldap/role/${rolename}" creation_ldif="${creation_ldif}" deletion_ldif="${deletion_ldif}" default_ttl="5s" max_ttl="10s"
+    run vault write "openldap/roles/${rolename}" creation_ldif="${creation_ldif}" deletion_ldif="${deletion_ldif}" default_ttl="5s" max_ttl="10s"
     [ ${status} -eq 0 ]
   done
 
   # Test list
-  run vault list -format=json openldap/role
+  run vault list -format=json openldap/roles
   [ ${status} -eq 0 ]
 
   expected='[
@@ -275,11 +275,11 @@ teardown() {
   max_ttl=20
 
   # Create role
-  run vault write openldap/role/testrole creation_ldif="${creation_ldif}" deletion_ldif="${deletion_ldif}" rollback_ldif="${deletion_ldif}" default_ttl="${default_ttl}s" max_ttl="${max_ttl}s"
+  run vault write openldap/roles/testrole creation_ldif="${creation_ldif}" deletion_ldif="${deletion_ldif}" rollback_ldif="${deletion_ldif}" default_ttl="${default_ttl}s" max_ttl="${max_ttl}s"
   [ ${status} -eq 0 ]
 
   # Get credentials
-  run vault read -format=json openldap/cred/testrole
+  run vault read -format=json openldap/creds/testrole
   [ ${status} -eq 0 ]
 
 
@@ -326,12 +326,12 @@ teardown() {
   max_ttl=20
 
   # Create role
-  run vault write openldap/role/testrole creation_ldif="${creation_ldif}" deletion_ldif="${deletion_ldif}" default_ttl="${default_ttl}s" max_ttl="${max_ttl}s"
+  run vault write openldap/roles/testrole creation_ldif="${creation_ldif}" deletion_ldif="${deletion_ldif}" default_ttl="${default_ttl}s" max_ttl="${max_ttl}s"
   [ ${status} -eq 0 ]
 
   # Get credentials
   log "Generating credentials..."
-  run vault read -format=json openldap/cred/testrole
+  run vault read -format=json openldap/creds/testrole
   [ ${status} -eq 0 ]
 
   lease_id=$(echo "${output}" | jq -r .lease_id)
@@ -418,11 +418,11 @@ memberOf: cn=dev,ou=groups,dc=learn,dc=example
 userPassword: {{.Password}}'
 
   # Create role
-  run vault write openldap/role/testrole creation_ldif="${bad_creation_ldif}" deletion_ldif="${deletion_ldif}" rollback_ldif="${deletion_ldif}" default_ttl="${default_ttl}s" max_ttl="${max_ttl}s"
+  run vault write openldap/roles/testrole creation_ldif="${bad_creation_ldif}" deletion_ldif="${deletion_ldif}" rollback_ldif="${deletion_ldif}" default_ttl="${default_ttl}s" max_ttl="${max_ttl}s"
   [ ${status} -eq 0 ]
 
   # Get credentials
-  run vault read -format=json openldap/cred/testrole
+  run vault read -format=json openldap/creds/testrole
   [ ${status} -ne 0 ]
   [[ "${output}" == *"failed to create user" ]]
 

--- a/scripts/acceptance-tests.bats
+++ b/scripts/acceptance-tests.bats
@@ -183,11 +183,11 @@ teardown() {
   vault delete openldap/config
 
   # Remove any roles that were created so they don't bleed over to other tests
-  output=$(vault list -format=json openldap/roles || true) # "or true" so it doesn't show an error if there are no roles
+  output=$(vault list -format=json openldap/role || true) # "or true" so it doesn't show an error if there are no roles
 
   roles=$(echo "${output}" | jq -r .[])
   for role in ${roles}; do
-    vault delete "openldap/roles/${role}" > /dev/null
+    vault delete "openldap/role/${role}" > /dev/null
   done
 }
 
@@ -196,11 +196,11 @@ teardown() {
   max_ttl=10
 
   # Create role
-  run vault write openldap/roles/testrole creation_ldif="${creation_ldif}" deletion_ldif="${deletion_ldif}" default_ttl="${default_ttl}s" max_ttl="${max_ttl}s"
+  run vault write openldap/role/testrole creation_ldif="${creation_ldif}" deletion_ldif="${deletion_ldif}" default_ttl="${default_ttl}s" max_ttl="${max_ttl}s"
   [ ${status} -eq 0 ]
 
   # Read role and make sure it matches what we expect
-  run vault read openldap/roles/testrole -format=json
+  run vault read openldap/role/testrole -format=json
   [ ${status} -eq 0 ]
   expected='{
     "creation_ldif": "dn: cn={{.Username}},ou=users,dc=learn,dc=example\nobjectClass: person\nobjectClass: top\ncn: learn\nsn: learn-{{.Username | utf16le | base64}}\nmemberOf: cn=dev,ou=groups,dc=learn,dc=example\nuserPassword: {{.Password}}",
@@ -215,10 +215,10 @@ teardown() {
   [ "${output}" == "true" ]
 
   ## Delete the role and ensure that it and the creds endpoint isn't readable
-  run vault delete openldap/roles/testrole
+  run vault delete openldap/role/testrole
   [ ${status} -eq 0 ]
 
-  run vault read openldap/roles/testrole
+  run vault read openldap/role/testrole
   [ ${status} -ne 0 ]
 
   run vault read openldap/creds/testrole
@@ -229,16 +229,16 @@ teardown() {
   # Create a bunch of roles with different prefixes
   for id in $(seq -f "%02g" 0 10); do
     rolename="testrole${id}"
-    run vault write "openldap/roles/${rolename}" creation_ldif="${creation_ldif}" deletion_ldif="${deletion_ldif}" default_ttl="5s" max_ttl="10s"
+    run vault write "openldap/role/${rolename}" creation_ldif="${creation_ldif}" deletion_ldif="${deletion_ldif}" default_ttl="5s" max_ttl="10s"
     [ ${status} -eq 0 ]
 
     rolename="roletest${id}"
-    run vault write "openldap/roles/${rolename}" creation_ldif="${creation_ldif}" deletion_ldif="${deletion_ldif}" default_ttl="5s" max_ttl="10s"
+    run vault write "openldap/role/${rolename}" creation_ldif="${creation_ldif}" deletion_ldif="${deletion_ldif}" default_ttl="5s" max_ttl="10s"
     [ ${status} -eq 0 ]
   done
 
   # Test list
-  run vault list -format=json openldap/roles
+  run vault list -format=json openldap/role
   [ ${status} -eq 0 ]
 
   expected='[
@@ -275,7 +275,7 @@ teardown() {
   max_ttl=20
 
   # Create role
-  run vault write openldap/roles/testrole creation_ldif="${creation_ldif}" deletion_ldif="${deletion_ldif}" rollback_ldif="${deletion_ldif}" default_ttl="${default_ttl}s" max_ttl="${max_ttl}s"
+  run vault write openldap/role/testrole creation_ldif="${creation_ldif}" deletion_ldif="${deletion_ldif}" rollback_ldif="${deletion_ldif}" default_ttl="${default_ttl}s" max_ttl="${max_ttl}s"
   [ ${status} -eq 0 ]
 
   # Get credentials
@@ -326,7 +326,7 @@ teardown() {
   max_ttl=20
 
   # Create role
-  run vault write openldap/roles/testrole creation_ldif="${creation_ldif}" deletion_ldif="${deletion_ldif}" default_ttl="${default_ttl}s" max_ttl="${max_ttl}s"
+  run vault write openldap/role/testrole creation_ldif="${creation_ldif}" deletion_ldif="${deletion_ldif}" default_ttl="${default_ttl}s" max_ttl="${max_ttl}s"
   [ ${status} -eq 0 ]
 
   # Get credentials
@@ -418,7 +418,7 @@ memberOf: cn=dev,ou=groups,dc=learn,dc=example
 userPassword: {{.Password}}'
 
   # Create role
-  run vault write openldap/roles/testrole creation_ldif="${bad_creation_ldif}" deletion_ldif="${deletion_ldif}" rollback_ldif="${deletion_ldif}" default_ttl="${default_ttl}s" max_ttl="${max_ttl}s"
+  run vault write openldap/role/testrole creation_ldif="${bad_creation_ldif}" deletion_ldif="${deletion_ldif}" rollback_ldif="${deletion_ldif}" default_ttl="${default_ttl}s" max_ttl="${max_ttl}s"
   [ ${status} -eq 0 ]
 
   # Get credentials


### PR DESCRIPTION
- Renames `/cred` -> `/creds`
- Removes `prefix` argument from static creds endpoint (it isn't supported & was creating problems with the `path-help` command on Vault)
- Fixes creation error not showing up if a rollback failure occurs during dynamic credential creation