### PR TITLE
Add schema config to rotate-root

### DIFF
--- a/client.go
+++ b/client.go
@@ -62,7 +62,10 @@ func (c *Client) UpdatePassword(conf *client.Config, dn string, newPassword stri
 
 func (c *Client) UpdateRootPassword(conf *client.Config, newPassword string) error {
 	filters := map[*client.Field][]string{client.FieldRegistry.ObjectClass: {"*"}}
-	newValues := map[*client.Field][]string{client.FieldRegistry.UserPassword: {newPassword}}
+	newValues, err := client.GetSchemaFieldRegistry(conf.Schema, newPassword)
+	if err != nil {
+		return fmt.Errorf("error updating password: %s", err)
+	}
 
 	return c.ldap.UpdatePassword(conf, conf.BindDN, newValues, filters)
 }


### PR DESCRIPTION
This secret engine supports different flavors of LDAP such as Active Directory and RACF using the `schema` configuration. This configuration changes the LDAP modify request to change the stored password. For example, Active Directory stores the user password in `pwdUnicode`, while OpenLDAP uses `userPassword`.

A bug existed in the `rotate-root` endpoint where the root password did not consider the configured schema. The result of this bug means the password modification would be applied to the wrong field in Active Directory.