### PR TITLE
Fix early rotation for roles with WALs, handle multiple WALs per role

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -18,8 +18,6 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 		return nil, err
 	}
 
-	b.Logger().Info("started openldap", "version", "v0.3.0-prem-rotation-guard")
-
 	return b, nil
 }
 

--- a/backend.go
+++ b/backend.go
@@ -18,7 +18,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 		return nil, err
 	}
 
-	b.Logger().Info("started openldap", "version", "v0.5.1-prem-rotation-guard")
+	b.Logger().Info("started openldap", "version", "v0.3.0-prem-rotation-guard")
 
 	return b, nil
 }

--- a/backend.go
+++ b/backend.go
@@ -18,6 +18,8 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 		return nil, err
 	}
 
+	b.Logger().Info("started openldap", "version", "v0.5.1-prem-rotation-guard")
+
 	return b, nil
 }
 

--- a/backend_test.go
+++ b/backend_test.go
@@ -22,7 +22,7 @@ var (
 
 func getBackend(throwsErr bool) (*backend, logical.Storage) {
 	config := &logical.BackendConfig{
-		Logger: logging.NewVaultLogger(log.Error),
+		Logger: logging.NewVaultLogger(log.Debug),
 
 		System: &logical.StaticSystemView{
 			DefaultLeaseTTLVal: defaultLeaseTTLVal,

--- a/backend_test.go
+++ b/backend_test.go
@@ -42,7 +42,9 @@ func getBackend(throwsErr bool) (*backend, logical.Storage) {
 	b.cancelQueue = cancel
 
 	// Load queue and kickoff new periodic ticker
-	go b.initQueue(ictx, &logical.InitializationRequest{config.StorageView})
+	b.initQueue(ictx, &logical.InitializationRequest{
+		Storage: config.StorageView,
+	})
 
 	return b, config.StorageView
 }
@@ -66,7 +68,7 @@ func (f *fakeLdapClient) Get(_ *client.Config, _ string) (*client.Entry, error) 
 	return client.NewEntry(entry), err
 }
 
-func (f *fakeLdapClient) UpdatePassword(conf *client.Config, dn string, newPassword string) error {
+func (f *fakeLdapClient) UpdatePassword(_ *client.Config, _ string, _ string) error {
 	var err error
 	if f.throwErrs {
 		err = errors.New("forced error")
@@ -74,7 +76,7 @@ func (f *fakeLdapClient) UpdatePassword(conf *client.Config, dn string, newPassw
 	return err
 }
 
-func (f *fakeLdapClient) UpdateRootPassword(conf *client.Config, newPassword string) error {
+func (f *fakeLdapClient) UpdateRootPassword(_ *client.Config, _ string) error {
 	var err error
 	if f.throwErrs {
 		err = errors.New("forced error")
@@ -90,7 +92,7 @@ func (f *fakeLdapClient) Del(_ *client.Config, _ *ldap.DelRequest) error {
 	return fmt.Errorf("not implemented")
 }
 
-func (f *fakeLdapClient) Execute(conf *client.Config, entries []*ldif.Entry, continueOnError bool) (err error) {
+func (f *fakeLdapClient) Execute(_ *client.Config, _ []*ldif.Entry, _ bool) (err error) {
 	return fmt.Errorf("not implemented")
 }
 

--- a/path_rotate.go
+++ b/path_rotate.go
@@ -24,12 +24,12 @@ func (b *backend) pathRotateCredentials() []*framework.Path {
 			Fields:  map[string]*framework.FieldSchema{},
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.UpdateOperation: &framework.PathOperation{
-					Callback:                    b.pathRotateCredentialsUpdate,
+					Callback:                    b.pathRotateRootCredentialsUpdate,
 					ForwardPerformanceStandby:   true,
 					ForwardPerformanceSecondary: true,
 				},
 				logical.CreateOperation: &framework.PathOperation{
-					Callback:                    b.pathRotateCredentialsUpdate,
+					Callback:                    b.pathRotateRootCredentialsUpdate,
 					ForwardPerformanceStandby:   true,
 					ForwardPerformanceSecondary: true,
 				},
@@ -64,7 +64,7 @@ func (b *backend) pathRotateCredentials() []*framework.Path {
 	}
 }
 
-func (b *backend) pathRotateCredentialsUpdate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+func (b *backend) pathRotateRootCredentialsUpdate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	if _, hasTimeout := ctx.Deadline(); !hasTimeout {
 		var cancel func()
 		ctx, cancel = context.WithTimeout(ctx, defaultCtxTimeout)

--- a/path_rotate.go
+++ b/path_rotate.go
@@ -162,10 +162,8 @@ func (b *backend) pathRotateRoleCredentialsUpdate(ctx context.Context, req *logi
 	}
 
 	if err != nil {
-		return &logical.Response{
-			Warnings: []string{"unable to finish rotating credentials; retries will " +
-				"continue in the background but it is also safe to retry manually"},
-		}, err
+		return nil, fmt.Errorf("unable to finish rotating credentials; retries will "+
+			"continue in the background but it is also safe to retry manually: %w", err)
 	}
 
 	// We're not returning creds here because we do not know if its been processed

--- a/path_rotate.go
+++ b/path_rotate.go
@@ -133,10 +133,14 @@ func (b *backend) pathRotateRoleCredentialsUpdate(ctx context.Context, req *logi
 		}
 	}
 
-	resp, err := b.setStaticAccountPassword(ctx, req.Storage, &setStaticAccountInput{
+	input := &setStaticAccountInput{
 		RoleName: name,
 		Role:     role,
-	})
+	}
+	if walID, ok := item.Value.(string); ok {
+		input.WALID = walID
+	}
+	resp, err := b.setStaticAccountPassword(ctx, req.Storage, input)
 	if err != nil {
 		b.Logger().Warn("unable to rotate credentials in rotate-role", "error", err)
 		// Update the priority to re-try this rotation and re-add the item to

--- a/path_static_roles.go
+++ b/path_static_roles.go
@@ -162,7 +162,7 @@ func (b *backend) pathStaticRoleDelete(ctx context.Context, req *logical.Request
 			b.Logger().Debug("deleting WAL for deleted role", "WAL ID", walID, "role", name)
 			err = framework.DeleteWAL(ctx, req.Storage, walID)
 			if err != nil {
-				b.Logger().Debug("failed to delete WAL for deleted role", "WAL ID", walID)
+				b.Logger().Debug("failed to delete WAL for deleted role", "WAL ID", walID, "error", err)
 				merr = multierror.Append(merr, err)
 			}
 		}
@@ -256,7 +256,7 @@ func (b *backend) pathStaticRoleCreateUpdate(ctx context.Context, req *logical.R
 				b.Logger().Debug("deleting WAL for failed role creation", "WAL ID", resp.WALID, "role", name)
 				walDeleteErr := framework.DeleteWAL(ctx, req.Storage, resp.WALID)
 				if walDeleteErr != nil {
-					b.Logger().Debug("failed to delete WAL for failed role creation", "WAL ID", resp.WALID)
+					b.Logger().Debug("failed to delete WAL for failed role creation", "WAL ID", resp.WALID, "error", walDeleteErr)
 					var merr *multierror.Error
 					merr = multierror.Append(merr, err)
 					merr = multierror.Append(merr, fmt.Errorf("failed to clean up WAL from failed role creation: %w", walDeleteErr))

--- a/path_static_roles.go
+++ b/path_static_roles.go
@@ -159,8 +159,10 @@ func (b *backend) pathStaticRoleDelete(ctx context.Context, req *logical.Request
 			continue
 		}
 		if wal != nil && name == wal.RoleName {
+			b.Logger().Debug("deleting WAL for deleted role", "WAL ID", walID, "role", name)
 			err = framework.DeleteWAL(ctx, req.Storage, walID)
 			if err != nil {
+				b.Logger().Debug("failed to delete WAL for deleted role", "WAL ID", walID)
 				merr = multierror.Append(merr, err)
 			}
 		}
@@ -251,8 +253,10 @@ func (b *backend) pathStaticRoleCreateUpdate(ctx context.Context, req *logical.R
 		})
 		if err != nil {
 			if resp != nil && resp.WALID != "" {
+				b.Logger().Debug("deleting WAL for failed role creation", "WAL ID", resp.WALID, "role", name)
 				walDeleteErr := framework.DeleteWAL(ctx, req.Storage, resp.WALID)
 				if walDeleteErr != nil {
+					b.Logger().Debug("failed to delete WAL for failed role creation", "WAL ID", resp.WALID)
 					var merr *multierror.Error
 					merr = multierror.Append(merr, err)
 					merr = multierror.Append(merr, fmt.Errorf("failed to clean up WAL from failed role creation: %w", walDeleteErr))

--- a/path_static_roles.go
+++ b/path_static_roles.go
@@ -151,8 +151,8 @@ func (b *backend) pathStaticRoleDelete(ctx context.Context, req *logical.Request
 	if err != nil {
 		return nil, err
 	}
+	var merr *multierror.Error
 	for _, walID := range walIDs {
-		var merr *multierror.Error
 		wal, err := b.findStaticWAL(ctx, req.Storage, walID)
 		if err != nil {
 			merr = multierror.Append(merr, err)
@@ -164,11 +164,9 @@ func (b *backend) pathStaticRoleDelete(ctx context.Context, req *logical.Request
 				merr = multierror.Append(merr, err)
 			}
 		}
-
-		return nil, merr.ErrorOrNil()
 	}
 
-	return nil, nil
+	return nil, merr.ErrorOrNil()
 }
 
 func (b *backend) pathStaticRoleRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {

--- a/path_static_roles_test.go
+++ b/path_static_roles_test.go
@@ -598,34 +598,3 @@ func configureOpenLDAPMount(t *testing.T, b *backend, storage logical.Storage) {
 		t.Fatalf("err:%s resp:%#v\n", err, resp)
 	}
 }
-
-func generateWALFromFailedRotation(t *testing.T, b *backend, storage logical.Storage, roleName string) {
-	t.Helper()
-	// Fail to rotate the roles
-	ldapClient := b.client.(*fakeLdapClient)
-	originalValue := ldapClient.throwErrs
-	ldapClient.throwErrs = true
-	defer func() {
-		ldapClient.throwErrs = originalValue
-	}()
-
-	_, err := b.HandleRequest(context.Background(), &logical.Request{
-		Operation: logical.UpdateOperation,
-		Path:      "rotate-role/" + roleName,
-		Storage:   storage,
-	})
-	if err == nil {
-		t.Fatal("expected error")
-	}
-}
-
-func requireWALs(t *testing.T, storage logical.Storage, count int) {
-	t.Helper()
-	wals, err := storage.List(context.Background(), "wal/")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(wals) != count {
-		t.Fatal("expected WALS", count, "got", len(wals))
-	}
-}

--- a/path_static_roles_test.go
+++ b/path_static_roles_test.go
@@ -2,6 +2,7 @@ package openldap
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/vault/sdk/logical"
@@ -75,6 +76,15 @@ func TestRoles(t *testing.T) {
 
 		if resp.Data["last_vault_rotation"] == nil {
 			t.Fatal("expected last_vault_rotation to not be empty")
+		}
+
+		// Assert that we cleared the WAL ID from the queue's data in the happy path.
+		item, err := b.credRotationQueue.PopByKey("hashicorp")
+		if err != nil {
+			t.Fatal()
+		}
+		if item.Value != "" {
+			t.Fatal()
 		}
 	})
 	t.Run("happy path with roles", func(t *testing.T) {
@@ -451,4 +461,186 @@ func TestListRoles(t *testing.T) {
 			t.Fatalf("expected list with %d keys, got %d", 2, len(resp.Data["keys"].([]string)))
 		}
 	})
+}
+
+func TestWALsStillTrackedAfterUpdate(t *testing.T) {
+	ctx := context.Background()
+	b, storage := getBackend(false)
+	defer b.Cleanup(ctx)
+	configureOpenLDAPMount(t, b, storage)
+
+	_, err := b.HandleRequest(ctx, &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      staticRolePath + "hashicorp",
+		Storage:   storage,
+		Data: map[string]interface{}{
+			"username":        "hashicorp",
+			"dn":              "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
+			"rotation_period": "5s",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	generateWALFromFailedRotation(t, b, storage, "hashicorp")
+	requireWALs(t, storage, 1)
+
+	_, err = b.HandleRequest(ctx, &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      staticRolePath + "hashicorp",
+		Storage:   storage,
+		Data: map[string]interface{}{
+			"username":        "hashicorp",
+			"dn":              "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
+			"rotation_period": "60s",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireWALs(t, storage, 1)
+
+	// Check we've still got track of it in the queue as well
+	item, err := b.credRotationQueue.PopByKey("hashicorp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wal, ok := item.Value.(string); !ok || wal == "" {
+		t.Fatal("should have a WAL ID in the rotation queue")
+	}
+}
+
+func TestWALsDeletedOnRoleCreationFailed(t *testing.T) {
+	ctx := context.Background()
+	b, storage := getBackend(true)
+	defer b.Cleanup(ctx)
+	configureOpenLDAPMount(t, b, storage)
+
+	for i := 0; i < 3; i++ {
+		_, err := b.HandleRequest(ctx, &logical.Request{
+			Operation: logical.CreateOperation,
+			Path:      staticRolePath + "hashicorp",
+			Storage:   storage,
+			Data: map[string]interface{}{
+				"username":        "hashicorp",
+				"dn":              "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
+				"rotation_period": "5s",
+			},
+		})
+		if err == nil {
+			t.Fatal("expected error from OpenLDAP")
+		}
+	}
+
+	requireWALs(t, storage, 0)
+}
+
+func TestWALsDeletedOnRoleDeletion(t *testing.T) {
+	ctx := context.Background()
+	b, storage := getBackend(false)
+	defer b.Cleanup(ctx)
+	configureOpenLDAPMount(t, b, storage)
+
+	// Create the roles
+	roleNames := []string{"hashicorp", "2"}
+	for _, roleName := range roleNames {
+		_, err := b.HandleRequest(ctx, &logical.Request{
+			Operation: logical.CreateOperation,
+			Path:      "static-role/" + roleName,
+			Storage:   storage,
+			Data: map[string]interface{}{
+				"username":        roleName,
+				"dn":              "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
+				"rotation_period": "5s",
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Fail to rotate the roles
+	for _, roleName := range roleNames {
+		generateWALFromFailedRotation(t, b, storage, roleName)
+	}
+
+	// Should have 2 WALs hanging around
+	requireWALs(t, storage, 2)
+
+	// Delete one of the static roles
+	_, err := b.HandleRequest(ctx, &logical.Request{
+		Operation: logical.DeleteOperation,
+		Path:      "static-role/hashicorp",
+		Storage:   storage,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	walIDs, err := storage.List(context.Background(), "wal/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, walID := range walIDs {
+		fmt.Println(walID)
+		wal, err := storage.Get(ctx, "wal/"+walID)
+		if err != nil {
+			fmt.Println("error retrieving wal", walID, err)
+		}
+		fmt.Printf("%+v\n", string(wal.Value))
+	}
+
+	// 1 WAL should be cleared by the delete
+	requireWALs(t, storage, 1)
+}
+
+func configureOpenLDAPMount(t *testing.T, b *backend, storage logical.Storage) {
+	t.Helper()
+	resp, err := b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      configPath,
+		Storage:   storage,
+		Data: map[string]interface{}{
+			"binddn":      "tester",
+			"bindpass":    "pa$$w0rd",
+			"url":         "ldap://138.91.247.105",
+			"certificate": validCertificate,
+		},
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+}
+
+func generateWALFromFailedRotation(t *testing.T, b *backend, storage logical.Storage, roleName string) {
+	t.Helper()
+	// Fail to rotate the roles
+	ldapClient := b.client.(*fakeLdapClient)
+	originalValue := ldapClient.throwErrs
+	ldapClient.throwErrs = true
+	defer func() {
+		ldapClient.throwErrs = originalValue
+	}()
+
+	_, err := b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "rotate-role/" + roleName,
+		Storage:   storage,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func requireWALs(t *testing.T, storage logical.Storage, count int) {
+	t.Helper()
+	wals, err := storage.List(context.Background(), "wal/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(wals) != count {
+		t.Fatal("expected WALS", count, "got", len(wals))
+	}
+	fmt.Println(wals)
 }

--- a/path_static_roles_test.go
+++ b/path_static_roles_test.go
@@ -2,7 +2,6 @@ package openldap
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/vault/sdk/logical"
@@ -578,19 +577,6 @@ func TestWALsDeletedOnRoleDeletion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	walIDs, err := storage.List(context.Background(), "wal/")
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, walID := range walIDs {
-		fmt.Println(walID)
-		wal, err := storage.Get(ctx, "wal/"+walID)
-		if err != nil {
-			fmt.Println("error retrieving wal", walID, err)
-		}
-		fmt.Printf("%+v\n", string(wal.Value))
-	}
-
 	// 1 WAL should be cleared by the delete
 	requireWALs(t, storage, 1)
 }
@@ -642,5 +628,4 @@ func requireWALs(t *testing.T, storage logical.Storage, count int) {
 	if len(wals) != count {
 		t.Fatal("expected WALS", count, "got", len(wals))
 	}
-	fmt.Println(wals)
 }

--- a/rotation.go
+++ b/rotation.go
@@ -489,18 +489,18 @@ func (b *backend) loadStaticWALs(ctx context.Context, s logical.Storage) (map[st
 			if walEntry.walCreatedAt > existingWALEntry.walCreatedAt {
 				// If the existing WAL is older, delete it from storage and fall
 				// through to inserting our current WAL into the map.
-				b.Logger().Debug("deleting stale WAL", "WAL ID", existingWALEntry.walID)
+				b.Logger().Debug("deleting stale loaded WAL", "WAL ID", existingWALEntry.walID)
 				err = framework.DeleteWAL(ctx, s, existingWALEntry.walID)
 				if err != nil {
-					b.Logger().Warn("unable to delete WAL", "error", err, "WAL ID", existingWALEntry.walID)
+					b.Logger().Warn("unable to delete loaded WAL", "error", err, "WAL ID", existingWALEntry.walID)
 				}
 			} else {
 				// If we already have a more recent WAL entry in the map, delete
 				// this one and continue onto the next WAL.
-				b.Logger().Debug("deleting stale WAL", "WAL ID", walEntry.walID)
+				b.Logger().Debug("deleting stale candidate WAL", "WAL ID", walEntry.walID)
 				err = framework.DeleteWAL(ctx, s, walID)
 				if err != nil {
-					b.Logger().Warn("unable to delete WAL", "error", err, "WAL ID", walEntry.walID)
+					b.Logger().Warn("unable to delete candidate WAL", "error", err, "WAL ID", walEntry.walID)
 				}
 				continue
 			}

--- a/rotation.go
+++ b/rotation.go
@@ -123,7 +123,6 @@ func (b *backend) runTicker(ctx context.Context, s logical.Storage) {
 // credential setting or rotation in the event of partial failure.
 type setCredentialsWAL struct {
 	NewPassword string `json:"new_password"`
-	OldPassword string `json:"old_password"`
 	RoleName    string `json:"role_name"`
 	Username    string `json:"username"`
 	DN          string `json:"dn"`
@@ -261,7 +260,6 @@ func (b *backend) findStaticWAL(ctx context.Context, s logical.Storage, id strin
 		walID:        id,
 		walCreatedAt: wal.CreatedAt,
 		NewPassword:  data["new_password"].(string),
-		OldPassword:  data["old_password"].(string),
 		RoleName:     data["role_name"].(string),
 		Username:     data["username"].(string),
 		DN:           data["dn"].(string),
@@ -363,7 +361,6 @@ func (b *backend) setStaticAccountPassword(ctx context.Context, s logical.Storag
 			Username:          input.Role.StaticAccount.Username,
 			DN:                input.Role.StaticAccount.DN,
 			NewPassword:       newPassword,
-			OldPassword:       input.Role.StaticAccount.Password,
 			LastVaultRotation: input.Role.StaticAccount.LastVaultRotation,
 		})
 		if err != nil {

--- a/rotation.go
+++ b/rotation.go
@@ -80,7 +80,7 @@ func (b *backend) populateQueue(ctx context.Context, s logical.Storage) {
 				log.Info("adjusting priority for Role")
 				item.Value = walEntry.walID
 				item.Priority = time.Now().Unix()
-				log.Debug("adjusted Role", "WAL ID", walEntry.walID, "priority", time.Unix(item.Priority,0))
+				log.Debug("adjusted Role", "WAL ID", walEntry.walID, "priority", time.Unix(item.Priority, 0))
 			}
 		}
 

--- a/rotation.go
+++ b/rotation.go
@@ -367,6 +367,14 @@ func (b *backend) setStaticAccountPassword(ctx context.Context, s logical.Storag
 		b.Logger().Debug("writing WAL", "role", input.RoleName, "WAL ID", output.WALID)
 	}
 
+	if newPassword == "" {
+		b.Logger().Error("newPassword was empty, re-generating based on the password policy")
+		newPassword, err = b.GeneratePassword(ctx, config)
+		if err != nil {
+			return output, err
+		}
+	}
+
 	// Update the password remotely.
 	if err := b.client.UpdatePassword(config.LDAP, input.Role.StaticAccount.DN, newPassword); err != nil {
 		return output, err

--- a/rotation.go
+++ b/rotation.go
@@ -200,7 +200,7 @@ func (b *backend) rotateCredential(ctx context.Context, s logical.Storage) bool 
 		if err := b.pushItem(item); err != nil {
 			b.Logger().Error("unable to push item on to queue", "error", err)
 		}
-		return true
+		return false
 	}
 
 	input := &setStaticAccountInput{

--- a/rotation.go
+++ b/rotation.go
@@ -354,6 +354,7 @@ func (b *backend) setStaticAccountPassword(ctx context.Context, s logical.Storag
 		if err != nil {
 			return output, err
 		}
+		b.Logger().Debug("writing WAL", "role", input.RoleName, "WAL ID", output.WALID)
 		output.WALID, err = framework.PutWAL(ctx, s, staticWALKey, &setCredentialsWAL{
 			RoleName:          input.RoleName,
 			Username:          input.Role.StaticAccount.Username,
@@ -364,7 +365,6 @@ func (b *backend) setStaticAccountPassword(ctx context.Context, s logical.Storag
 		if err != nil {
 			return output, errwrap.Wrapf("error writing WAL entry: {{err}}", err)
 		}
-		b.Logger().Debug("writing WAL", "role", input.RoleName, "WAL ID", output.WALID)
 	}
 
 	if newPassword == "" {

--- a/rotation.go
+++ b/rotation.go
@@ -70,12 +70,12 @@ func (b *backend) populateQueue(ctx context.Context, s logical.Storage) {
 		if walEntry != nil {
 			// Check walEntry last vault time
 			if !walEntry.LastVaultRotation.IsZero() && walEntry.LastVaultRotation.Before(role.StaticAccount.LastVaultRotation) {
-				log.Debug("deleting outdated WAL", "WAL ID", walEntry.walID)
 				// WAL's last vault rotation record is older than the role's data, so
 				// delete and move on
 				if err := framework.DeleteWAL(ctx, s, walEntry.walID); err != nil {
 					log.Warn("unable to delete WAL", "error", err, "WAL ID", walEntry.walID)
 				}
+				log.Debug("deleted outdated WAL", "WAL ID", walEntry.walID)
 			} else {
 				log.Info("adjusting priority for Role")
 				item.Value = walEntry.walID
@@ -489,6 +489,7 @@ func (b *backend) loadStaticWALs(ctx context.Context, s logical.Storage) (map[st
 			if err := framework.DeleteWAL(ctx, s, walEntry.walID); err != nil {
 				b.Logger().Warn("unable to delete WAL", "error", err, "WAL ID", walEntry.walID)
 			}
+			b.Logger().Debug("deleted WAL with nil role or static account", "WAL ID", walEntry.walID)
 			continue
 		}
 

--- a/rotation.go
+++ b/rotation.go
@@ -363,6 +363,7 @@ func (b *backend) setStaticAccountPassword(ctx context.Context, s logical.Storag
 		if err != nil {
 			return output, errwrap.Wrapf("error writing WAL entry: {{err}}", err)
 		}
+		b.Logger().Debug("writing WAL", "WAL ID", output.WALID)
 	}
 
 	// Update the password remotely.
@@ -399,9 +400,11 @@ to %s, configure a new binddn and bindpass to restore openldap function`, pwdSto
 
 	// Cleanup WAL after successfully rotating and pushing new item on to queue
 	if err := framework.DeleteWAL(ctx, s, output.WALID); err != nil {
+		b.Logger().Warn("error deleting WAL", "WAL ID", output.WALID, "error", err)
 		merr = multierror.Append(merr, err)
 		return output, merr
 	}
+	b.Logger().Debug("deleted WAL", "WAL ID", output.WALID)
 
 	// The WAL has been deleted, return new setStaticAccountOutput without it
 	return &setStaticAccountOutput{RotationTime: lvr}, merr

--- a/rotation_test.go
+++ b/rotation_test.go
@@ -103,3 +103,97 @@ func TestAutoRotate(t *testing.T) {
 		}
 	})
 }
+
+func TestRollsPasswordForwards(t *testing.T) {
+	ctx := context.Background()
+	b, storage := getBackend(false)
+	defer b.Cleanup(ctx)
+	configureOpenLDAPMount(t, b, storage)
+
+	// Create the role
+	_, err := b.HandleRequest(ctx, &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "static-role/hashicorp",
+		Storage:   storage,
+		Data: map[string]interface{}{
+			"username":        "hashicorp",
+			"dn":              "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
+			"rotation_period": "86400s",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	generateWALFromFailedRotation(t, b, storage, "hashicorp")
+	walIDs, err := storage.List(context.Background(), "wal/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(walIDs) != 1 {
+		t.Fatal("expected 1 WAL, got", len(walIDs))
+	}
+	wal, err := b.findStaticWAL(ctx, storage, walIDs[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	role, err := b.staticRole(ctx, storage, "hashicorp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Role's password should still be the WAL's old password
+	if role.StaticAccount.Password != wal.OldPassword {
+		t.Fatal(role.StaticAccount.Password, wal.OldPassword)
+	}
+
+	// Trigger a retry on the rotation, it should use WAL's new password
+	_, err = b.HandleRequest(ctx, &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "rotate-role/hashicorp",
+		Storage:   storage,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	role, err = b.staticRole(ctx, storage, "hashicorp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if role.StaticAccount.Password != wal.NewPassword {
+		t.Fatal(role.StaticAccount.Password, wal.NewPassword)
+	}
+	// WAL should be cleared by the successful rotate
+	requireWALs(t, storage, 0)
+}
+
+func generateWALFromFailedRotation(t *testing.T, b *backend, storage logical.Storage, roleName string) {
+	t.Helper()
+	// Fail to rotate the roles
+	ldapClient := b.client.(*fakeLdapClient)
+	originalValue := ldapClient.throwErrs
+	ldapClient.throwErrs = true
+	defer func() {
+		ldapClient.throwErrs = originalValue
+	}()
+
+	_, err := b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "rotate-role/" + roleName,
+		Storage:   storage,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func requireWALs(t *testing.T, storage logical.Storage, expectedCount int) {
+	t.Helper()
+	wals, err := storage.List(context.Background(), "wal/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(wals) != expectedCount {
+		t.Fatal("expected WALs", expectedCount, "got", len(wals))
+	}
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -21,10 +21,6 @@ SCRATCH="$DIR/tmp"
 mkdir -p "$SCRATCH/plugins"
 
 echo "--> Vault server"
-echo "    Writing config"
-tee "$SCRATCH/vault.hcl" > /dev/null <<EOF
-plugin_directory = "$SCRATCH/plugins"
-EOF
 
 echo "    Envvars"
 export VAULT_DEV_ROOT_TOKEN_ID="root"
@@ -33,17 +29,18 @@ export VAULT_ADDR="http://127.0.0.1:8200"
 echo "    Starting"
 vault server \
   -dev \
+  -dev-root-token-id=root \
+  -dev-plugin-dir="$SCRATCH/plugins" \
   -log-level="debug" \
-  -config="$SCRATCH/vault.hcl" \
-  -dev-ha -dev-transactional -dev-root-token-id=root \
   &
-sleep 2
 VAULT_PID=$!
+sleep 2
 
 function cleanup {
   echo ""
   echo "==> Cleaning up"
   kill -INT "$VAULT_PID"
+  wait $VAULT_PID
   rm -rf "$SCRATCH"
 }
 trap cleanup EXIT


### PR DESCRIPTION
# Early rotation of credentials

## Bug and repro description

When the plugin finds a WAL for a role on initialisation, it (understandably) assumes it needs to rotate the password for the role ASAP. However, the plugin also assumes there can be at most 1 WAL per role at any time, and that's not true. We can have arbitrarily old and stale WALs in storage generated by failures during manual attempts to set up or rotate a role. These only ever get a chance to be cleaned up one at a time for each initialisation the plugin goes through. As a result, we can see early password rotations occur when the plugin runs initialisation.

To illustrate, here is a scenario to reproduce an early rotation:

```bash
vault write openldap/config \
    url=ldaps://vault-ad-test.example.com\
    binddn="CN=vault-ad-admin,CN=Users,DC=example,DC=com" \
    bindpass="some-password" \
    schema=ad

# Ensure the AD server is down so that this command fails
# No storage entry gets created for the role itself, but it will leave a WAL behind in storage for the role anyway
vault write openldap/static-role/mary \
    dn="CN=mary.smith,CN=Users,DC=example,DC=com" \
    username="mary.smith" \
    rotation_period="48h"

# To observe the dangling WAL, check the sys/raw endpoint, which should return a single WAL
MOUNT_UUID=$(vault read -format=json sys/mounts | jq -r '.data["openldap/"].uuid')
vault list sys/raw/logical/$MOUNT_UUID/wal

# Now ensure the AD server is up again
# This command should succeed, in which case create and then quickly delete a WAL, but leave the original WAL untouched
vault write openldap/static-role/mary \
    dn="CN=mary.smith,CN=Users,DC=example,DC=com" \
    username="mary.smith" \
    rotation_period="48h"

# Still 1 WAL
vault list sys/raw/logical/$MOUNT_UUID/wal

# Read the creds
vault read openldap/static-cred/mary

# Reload the plugin, and on initialisation, it will see the first WAL we created and immediately rotate the role, even though it's already been rotated very recently.
vault write sys/plugins/reload/backend mounts=openldap/

# Read the creds again, and you should see they've been rotated
vault read openldap/static-cred/mary
# WAL has been cleared
vault list sys/raw/logical/$MOUNT_UUID/wal
```

## Fix

There are a few meaningful changes:

1. Logging updates
2. Ensure a maximum of 1 WAL per role. There are some areas where we lose track of an existing WAL ID and end up creating an extra WAL for the role instead
3. Use the new password stored in the WAL when available. Previously we generated a new password on every attempt. This ensures we perform fewer rotations when we retry after failed attempts.
4. Delete stale WALs from storage as we load them. Without the above bug fix, this would be a pretty effective mitigation, but as it is, the main motivation now is to avoid a resource leak.
5. Discard WALs that have a last rotation time of 0. They should only be possible when they exist as a hangover from a previous failed attempt to create a role in Vault, and so we should be able to always safely ignore them.