### PR TITLE
Backport 1.8.x: Fix early rotation for roles with WALs, ensure <=1 WAL per role (#28)

### DIFF
--- a/backend_test.go
+++ b/backend_test.go
@@ -22,7 +22,7 @@ var (
 
 func getBackend(throwsErr bool) (*backend, logical.Storage) {
 	config := &logical.BackendConfig{
-		Logger: logging.NewVaultLogger(log.Error),
+		Logger: logging.NewVaultLogger(log.Debug),
 
 		System: &logical.StaticSystemView{
 			DefaultLeaseTTLVal: defaultLeaseTTLVal,
@@ -42,7 +42,9 @@ func getBackend(throwsErr bool) (*backend, logical.Storage) {
 	b.cancelQueue = cancel
 
 	// Load queue and kickoff new periodic ticker
-	go b.initQueue(ictx, &logical.InitializationRequest{config.StorageView})
+	b.initQueue(ictx, &logical.InitializationRequest{
+		Storage: config.StorageView,
+	})
 
 	return b, config.StorageView
 }
@@ -66,7 +68,7 @@ func (f *fakeLdapClient) Get(_ *client.Config, _ string) (*client.Entry, error) 
 	return client.NewEntry(entry), err
 }
 
-func (f *fakeLdapClient) UpdatePassword(conf *client.Config, dn string, newPassword string) error {
+func (f *fakeLdapClient) UpdatePassword(_ *client.Config, _ string, _ string) error {
 	var err error
 	if f.throwErrs {
 		err = errors.New("forced error")
@@ -74,7 +76,7 @@ func (f *fakeLdapClient) UpdatePassword(conf *client.Config, dn string, newPassw
 	return err
 }
 
-func (f *fakeLdapClient) UpdateRootPassword(conf *client.Config, newPassword string) error {
+func (f *fakeLdapClient) UpdateRootPassword(_ *client.Config, _ string) error {
 	var err error
 	if f.throwErrs {
 		err = errors.New("forced error")
@@ -90,7 +92,7 @@ func (f *fakeLdapClient) Del(_ *client.Config, _ *ldap.DelRequest) error {
 	return fmt.Errorf("not implemented")
 }
 
-func (f *fakeLdapClient) Execute(conf *client.Config, entries []*ldif.Entry, continueOnError bool) (err error) {
+func (f *fakeLdapClient) Execute(_ *client.Config, _ []*ldif.Entry, _ bool) (err error) {
 	return fmt.Errorf("not implemented")
 }
 

--- a/path_static_roles.go
+++ b/path_static_roles.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/locksutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -146,7 +147,28 @@ func (b *backend) pathStaticRoleDelete(ctx context.Context, req *logical.Request
 		return nil, err
 	}
 
-	return nil, nil
+	walIDs, err := framework.ListWAL(ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+	var merr *multierror.Error
+	for _, walID := range walIDs {
+		wal, err := b.findStaticWAL(ctx, req.Storage, walID)
+		if err != nil {
+			merr = multierror.Append(merr, err)
+			continue
+		}
+		if wal != nil && name == wal.RoleName {
+			b.Logger().Debug("deleting WAL for deleted role", "WAL ID", walID, "role", name)
+			err = framework.DeleteWAL(ctx, req.Storage, walID)
+			if err != nil {
+				b.Logger().Debug("failed to delete WAL for deleted role", "WAL ID", walID, "error", err)
+				merr = multierror.Append(merr, err)
+			}
+		}
+	}
+
+	return nil, merr.ErrorOrNil()
 }
 
 func (b *backend) pathStaticRoleRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
@@ -221,6 +243,7 @@ func (b *backend) pathStaticRoleCreateUpdate(ctx context.Context, req *logical.R
 
 	// Only call setStaticAccountPassword if we're creating the role for the
 	// first time
+	var item *queue.Item
 	switch req.Operation {
 	case logical.CreateOperation:
 		// setStaticAccountPassword calls Storage.Put and saves the role to storage
@@ -229,10 +252,24 @@ func (b *backend) pathStaticRoleCreateUpdate(ctx context.Context, req *logical.R
 			Role:     role,
 		})
 		if err != nil {
+			if resp != nil && resp.WALID != "" {
+				b.Logger().Debug("deleting WAL for failed role creation", "WAL ID", resp.WALID, "role", name)
+				walDeleteErr := framework.DeleteWAL(ctx, req.Storage, resp.WALID)
+				if walDeleteErr != nil {
+					b.Logger().Debug("failed to delete WAL for failed role creation", "WAL ID", resp.WALID, "error", walDeleteErr)
+					var merr *multierror.Error
+					merr = multierror.Append(merr, err)
+					merr = multierror.Append(merr, fmt.Errorf("failed to clean up WAL from failed role creation: %w", walDeleteErr))
+					err = merr.ErrorOrNil()
+				}
+			}
 			return nil, err
 		}
 		// guard against RotationTime not being set or zero-value
 		lvr = resp.RotationTime
+		item = &queue.Item{
+			Key: name,
+		}
 	case logical.UpdateOperation:
 		// store updated Role
 		entry, err := logical.StorageEntryJSON(staticRolePath+name, role)
@@ -244,20 +281,19 @@ func (b *backend) pathStaticRoleCreateUpdate(ctx context.Context, req *logical.R
 		}
 
 		// In case this is an update, remove any previous version of the item from
-		// the queue
-
+		// the queue. The existing item could be tracking a WAL ID for this role,
+		// so it's important to keep the existing item rather than recreate it.
 		//TODO: Add retry logic
-		_, err = b.popFromRotationQueueByKey(name)
+		item, err = b.popFromRotationQueueByKey(name)
 		if err != nil {
 			return nil, err
 		}
 	}
 
+	item.Priority = lvr.Add(role.StaticAccount.RotationPeriod).Unix()
+
 	// Add their rotation to the queue
-	if err := b.pushItem(&queue.Item{
-		Key:      name,
-		Priority: lvr.Add(role.StaticAccount.RotationPeriod).Unix(),
-	}); err != nil {
+	if err := b.pushItem(item); err != nil {
 		return nil, err
 	}
 

--- a/path_static_roles_test.go
+++ b/path_static_roles_test.go
@@ -2,6 +2,7 @@ package openldap
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/vault/sdk/logical"
@@ -451,4 +452,151 @@ func TestListRoles(t *testing.T) {
 			t.Fatalf("expected list with %d keys, got %d", 2, len(resp.Data["keys"].([]string)))
 		}
 	})
+}
+
+func TestWALsStillTrackedAfterUpdate(t *testing.T) {
+	ctx := context.Background()
+	b, storage := getBackend(false)
+	defer b.Cleanup(ctx)
+	configureOpenLDAPMount(t, b, storage)
+
+	createRole(t, b, storage, "hashicorp")
+
+	generateWALFromFailedRotation(t, b, storage, "hashicorp")
+	requireWALs(t, storage, 1)
+
+	_, err := b.HandleRequest(ctx, &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      staticRolePath + "hashicorp",
+		Storage:   storage,
+		Data: map[string]interface{}{
+			"username":        "hashicorp",
+			"dn":              "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
+			"rotation_period": "600s",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	walIDs := requireWALs(t, storage, 1)
+
+	// Now when we trigger a manual rotate, it should use the WAL's new password
+	// which will tell us that the in-memory structure still kept track of the
+	// WAL in addition to it still being in storage.
+	wal, err := b.findStaticWAL(ctx, storage, walIDs[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "rotate-role/hashicorp",
+		Storage:   storage,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	role, err := b.staticRole(ctx, storage, "hashicorp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if role.StaticAccount.Password != wal.NewPassword {
+		t.Fatal()
+	}
+	requireWALs(t, storage, 0)
+}
+
+func TestWALsDeletedOnRoleCreationFailed(t *testing.T) {
+	ctx := context.Background()
+	b, storage := getBackend(true)
+	defer b.Cleanup(ctx)
+	configureOpenLDAPMount(t, b, storage)
+
+	for i := 0; i < 3; i++ {
+		resp, err := b.HandleRequest(ctx, &logical.Request{
+			Operation: logical.CreateOperation,
+			Path:      staticRolePath + "hashicorp",
+			Storage:   storage,
+			Data: map[string]interface{}{
+				"username":        "hashicorp",
+				"dn":              "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
+				"rotation_period": "5s",
+			},
+		})
+		if err == nil {
+			t.Fatal("expected error from OpenLDAP")
+		}
+		if !strings.Contains(err.Error(), "forced error") {
+			t.Fatal("expected forced error message", resp, err)
+		}
+	}
+
+	requireWALs(t, storage, 0)
+}
+
+func TestWALsDeletedOnRoleDeletion(t *testing.T) {
+	ctx := context.Background()
+	b, storage := getBackend(false)
+	defer b.Cleanup(ctx)
+	configureOpenLDAPMount(t, b, storage)
+
+	// Create the roles
+	roleNames := []string{"hashicorp", "2"}
+	for _, roleName := range roleNames {
+		createRole(t, b, storage, roleName)
+	}
+
+	// Fail to rotate the roles
+	for _, roleName := range roleNames {
+		generateWALFromFailedRotation(t, b, storage, roleName)
+	}
+
+	// Should have 2 WALs hanging around
+	requireWALs(t, storage, 2)
+
+	// Delete one of the static roles
+	_, err := b.HandleRequest(ctx, &logical.Request{
+		Operation: logical.DeleteOperation,
+		Path:      "static-role/hashicorp",
+		Storage:   storage,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 1 WAL should be cleared by the delete
+	requireWALs(t, storage, 1)
+}
+
+func configureOpenLDAPMount(t *testing.T, b *backend, storage logical.Storage) {
+	t.Helper()
+	resp, err := b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      configPath,
+		Storage:   storage,
+		Data: map[string]interface{}{
+			"binddn":      "tester",
+			"bindpass":    "pa$$w0rd",
+			"url":         "ldap://138.91.247.105",
+			"certificate": validCertificate,
+		},
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+}
+
+func createRole(t *testing.T, b *backend, storage logical.Storage, roleName string) {
+	_, err := b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "static-role/" + roleName,
+		Storage:   storage,
+		Data: map[string]interface{}{
+			"username":        roleName,
+			"dn":              "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
+			"rotation_period": "86400s",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/rotation_test.go
+++ b/rotation_test.go
@@ -5,7 +5,11 @@ import (
 	"testing"
 	"time"
 
+	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/hashicorp/vault/sdk/queue"
 )
 
 func TestAutoRotate(t *testing.T) {
@@ -102,4 +106,254 @@ func TestAutoRotate(t *testing.T) {
 			t.Fatal("expected passwords to be different after auto rotation, they weren't")
 		}
 	})
+}
+
+func TestRollsPasswordForwardsUsingWAL(t *testing.T) {
+	ctx := context.Background()
+	b, storage := getBackend(false)
+	defer b.Cleanup(ctx)
+	configureOpenLDAPMount(t, b, storage)
+	createRole(t, b, storage, "hashicorp")
+
+	role, err := b.staticRole(ctx, storage, "hashicorp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldPassword := role.StaticAccount.Password
+
+	generateWALFromFailedRotation(t, b, storage, "hashicorp")
+	walIDs := requireWALs(t, storage, 1)
+	wal, err := b.findStaticWAL(ctx, storage, walIDs[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	role, err = b.staticRole(ctx, storage, "hashicorp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Role's password should still be the WAL's old password
+	if role.StaticAccount.Password != oldPassword {
+		t.Fatal(role.StaticAccount.Password, oldPassword)
+	}
+
+	// Trigger a retry on the rotation, it should use WAL's new password
+	_, err = b.HandleRequest(ctx, &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "rotate-role/hashicorp",
+		Storage:   storage,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	role, err = b.staticRole(ctx, storage, "hashicorp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if role.StaticAccount.Password != wal.NewPassword {
+		t.Fatal(role.StaticAccount.Password, wal.NewPassword)
+	}
+	// WAL should be cleared by the successful rotate
+	requireWALs(t, storage, 0)
+}
+
+func TestStoredWALsCorrectlyProcessed(t *testing.T) {
+	const walNewPassword = "new-password-from-wal"
+	for _, tc := range []struct {
+		name         string
+		shouldRotate bool
+		wal          *setCredentialsWAL
+	}{
+		{
+			"WAL is kept and used for roll forward",
+			true,
+			&setCredentialsWAL{
+				RoleName:          "hashicorp",
+				Username:          "hashicorp",
+				DN:                "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
+				NewPassword:       walNewPassword,
+				LastVaultRotation: time.Now().Add(time.Hour),
+			},
+		},
+		{
+			"zero-time WAL is discarded on load",
+			false,
+			&setCredentialsWAL{
+				RoleName:          "hashicorp",
+				Username:          "hashicorp",
+				DN:                "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
+				NewPassword:       walNewPassword,
+				LastVaultRotation: time.Time{},
+			},
+		},
+		{
+			"empty-password WAL is kept but a new password is generated",
+			true,
+			&setCredentialsWAL{
+				RoleName:          "hashicorp",
+				Username:          "hashicorp",
+				DN:                "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
+				NewPassword:       "",
+				LastVaultRotation: time.Now().Add(time.Hour),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			config := &logical.BackendConfig{
+				Logger: logging.NewVaultLogger(log.Debug),
+
+				System: &logical.StaticSystemView{
+					DefaultLeaseTTLVal: defaultLeaseTTLVal,
+					MaxLeaseTTLVal:     maxLeaseTTLVal,
+				},
+				StorageView: &logical.InmemStorage{},
+			}
+
+			b := Backend(&fakeLdapClient{throwErrs: false})
+			b.Setup(context.Background(), config)
+
+			b.credRotationQueue = queue.New()
+			initCtx := context.Background()
+			ictx, cancel := context.WithCancel(initCtx)
+			b.cancelQueue = cancel
+
+			defer b.Cleanup(ctx)
+			configureOpenLDAPMount(t, b, config.StorageView)
+			createRole(t, b, config.StorageView, "hashicorp")
+			role, err := b.staticRole(ctx, config.StorageView, "hashicorp")
+			if err != nil {
+				t.Fatal(err)
+			}
+			initialPassword := role.StaticAccount.Password
+
+			// Set up a WAL for our test case
+			framework.PutWAL(ctx, config.StorageView, staticWALKey, tc.wal)
+			requireWALs(t, config.StorageView, 1)
+			// Reset the rotation queue to simulate startup memory state
+			b.credRotationQueue = queue.New()
+
+			// Now finish the startup process by populating the queue, which should discard the WAL
+			b.initQueue(ictx, &logical.InitializationRequest{
+				Storage: config.StorageView,
+			})
+
+			if tc.shouldRotate {
+				requireWALs(t, config.StorageView, 1)
+			} else {
+				requireWALs(t, config.StorageView, 0)
+			}
+
+			// Run one tick
+			b.rotateCredentials(ctx, config.StorageView)
+			requireWALs(t, config.StorageView, 0)
+
+			role, err = b.staticRole(ctx, config.StorageView, "hashicorp")
+			if err != nil {
+				t.Fatal(err)
+			}
+			item, err := b.popFromRotationQueueByKey("hashicorp")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if tc.shouldRotate {
+				if tc.wal.NewPassword != "" {
+					// Should use WAL's new_password field
+					if role.StaticAccount.Password != walNewPassword {
+						t.Fatal()
+					}
+				} else {
+					// Should rotate but ignore WAL's new_password field
+					if role.StaticAccount.Password == initialPassword {
+						t.Fatal()
+					}
+					if role.StaticAccount.Password == walNewPassword {
+						t.Fatal()
+					}
+				}
+			} else {
+				// Ensure the role was not promoted for early rotation
+				if item.Priority < time.Now().Add(time.Hour).Unix() {
+					t.Fatal("priority should be for about a week away, but was", item.Priority)
+				}
+				if role.StaticAccount.Password != initialPassword {
+					t.Fatal("password should not have been rotated yet")
+				}
+			}
+		})
+	}
+}
+
+func TestDeletesOlderWALsOnLoad(t *testing.T) {
+	ctx := context.Background()
+	b, storage := getBackend(false)
+	defer b.Cleanup(ctx)
+	configureOpenLDAPMount(t, b, storage)
+	createRole(t, b, storage, "hashicorp")
+
+	// Create 4 WALs, with a clear winner for most recent.
+	wal := &setCredentialsWAL{
+		RoleName:          "hashicorp",
+		Username:          "hashicorp",
+		DN:                "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
+		NewPassword:       "some-new-password",
+		LastVaultRotation: time.Now(),
+	}
+	for i := 0; i < 3; i++ {
+		_, err := framework.PutWAL(ctx, storage, staticWALKey, wal)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	time.Sleep(2 * time.Second)
+	// We expect this WAL to have the latest createdAt timestamp
+	walID, err := framework.PutWAL(ctx, storage, staticWALKey, wal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireWALs(t, storage, 4)
+
+	walMap, err := b.loadStaticWALs(ctx, storage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(walMap) != 1 || walMap["hashicorp"] == nil || walMap["hashicorp"].walID != walID {
+		t.Fatal()
+	}
+	requireWALs(t, storage, 1)
+}
+
+func generateWALFromFailedRotation(t *testing.T, b *backend, storage logical.Storage, roleName string) {
+	t.Helper()
+	// Fail to rotate the roles
+	ldapClient := b.client.(*fakeLdapClient)
+	originalValue := ldapClient.throwErrs
+	ldapClient.throwErrs = true
+	defer func() {
+		ldapClient.throwErrs = originalValue
+	}()
+
+	_, err := b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "rotate-role/" + roleName,
+		Storage:   storage,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// returns a slice of the WAL IDs in storage
+func requireWALs(t *testing.T, storage logical.Storage, expectedCount int) []string {
+	t.Helper()
+	wals, err := storage.List(context.Background(), "wal/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(wals) != expectedCount {
+		t.Fatal("expected WALs", expectedCount, "got", len(wals))
+	}
+
+	return wals
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -21,10 +21,6 @@ SCRATCH="$DIR/tmp"
 mkdir -p "$SCRATCH/plugins"
 
 echo "--> Vault server"
-echo "    Writing config"
-tee "$SCRATCH/vault.hcl" > /dev/null <<EOF
-plugin_directory = "$SCRATCH/plugins"
-EOF
 
 echo "    Envvars"
 export VAULT_DEV_ROOT_TOKEN_ID="root"
@@ -33,17 +29,18 @@ export VAULT_ADDR="http://127.0.0.1:8200"
 echo "    Starting"
 vault server \
   -dev \
+  -dev-root-token-id=root \
+  -dev-plugin-dir="$SCRATCH/plugins" \
   -log-level="debug" \
-  -config="$SCRATCH/vault.hcl" \
-  -dev-ha -dev-transactional -dev-root-token-id=root \
   &
-sleep 2
 VAULT_PID=$!
+sleep 2
 
 function cleanup {
   echo ""
   echo "==> Cleaning up"
   kill -INT "$VAULT_PID"
+  wait $VAULT_PID
   rm -rf "$SCRATCH"
 }
 trap cleanup EXIT


### PR DESCRIPTION
Backports #28 for 1.8.x