### PR TITLE
Fix WAL debug log line

### DIFF
--- a/rotation.go
+++ b/rotation.go
@@ -354,7 +354,6 @@ func (b *backend) setStaticAccountPassword(ctx context.Context, s logical.Storag
 		if err != nil {
 			return output, err
 		}
-		b.Logger().Debug("writing WAL", "role", input.RoleName, "WAL ID", output.WALID)
 		output.WALID, err = framework.PutWAL(ctx, s, staticWALKey, &setCredentialsWAL{
 			RoleName:          input.RoleName,
 			Username:          input.Role.StaticAccount.Username,
@@ -362,6 +361,7 @@ func (b *backend) setStaticAccountPassword(ctx context.Context, s logical.Storag
 			NewPassword:       newPassword,
 			LastVaultRotation: input.Role.StaticAccount.LastVaultRotation,
 		})
+		b.Logger().Debug("wrote WAL", "role", input.RoleName, "WAL ID", output.WALID)
 		if err != nil {
 			return output, errwrap.Wrapf("error writing WAL entry: {{err}}", err)
 		}


### PR DESCRIPTION
This was a late, flawed change from #28. The WAL ID is empty until after the call to `framework.PutWAL`.