### PR TITLE
Fix panic from nil logger

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -12,7 +12,7 @@ import (
 )
 
 func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
-	ldapClient := NewClient()
+	ldapClient := NewClient(conf)
 	b := Backend(ldapClient)
 	if err := b.Setup(ctx, conf); err != nil {
 		return nil, err
@@ -23,6 +23,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 
 func Backend(client ldapClient) *backend {
 	var b backend
+
 	b.Backend = &framework.Backend{
 		Help: strings.TrimSpace(backendHelp),
 

--- a/backend.go
+++ b/backend.go
@@ -12,7 +12,7 @@ import (
 )
 
 func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
-	ldapClient := NewClient(conf)
+	ldapClient := NewClient(conf.Logger)
 	b := Backend(ldapClient)
 	if err := b.Setup(ctx, conf); err != nil {
 		return nil, err

--- a/client.go
+++ b/client.go
@@ -26,6 +26,9 @@ func NewClient(conf *logical.BackendConfig) *Client {
 	}
 
 	logger := conf.Logger
+
+	// This can only happen in a test where BackendConfig is created
+	// manually without a logger.
 	if logger == nil {
 		logger = hclog.NewNullLogger()
 	}

--- a/client.go
+++ b/client.go
@@ -7,7 +7,6 @@ import (
 	"github.com/go-ldap/ldif"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault-plugin-secrets-openldap/client"
-	"github.com/hashicorp/vault/sdk/logical"
 )
 
 type ldapClient interface {
@@ -20,22 +19,10 @@ type ldapClient interface {
 	Execute(conf *client.Config, entries []*ldif.Entry, continueOnError bool) (err error)
 }
 
-func NewClient(conf *logical.BackendConfig) *Client {
-	client := &Client{
-		ldap: client.New(),
+func NewClient(logger hclog.Logger) *Client {
+	return &Client{
+		ldap: client.New(logger),
 	}
-
-	logger := conf.Logger
-
-	// This can only happen in a test where BackendConfig is created
-	// manually without a logger.
-	if logger == nil {
-		logger = hclog.NewNullLogger()
-	}
-
-	client.ldap.LDAP.Logger = logger
-
-	return client
 }
 
 var _ ldapClient = (*Client)(nil)

--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-ldap/ldap/v3"
 	"github.com/go-ldap/ldif"
 	"github.com/hashicorp/vault-plugin-secrets-openldap/client"
+	"github.com/hashicorp/vault/sdk/logical"
 )
 
 type ldapClient interface {
@@ -18,10 +19,13 @@ type ldapClient interface {
 	Execute(conf *client.Config, entries []*ldif.Entry, continueOnError bool) (err error)
 }
 
-func NewClient() *Client {
-	return &Client{
+func NewClient(conf *logical.BackendConfig) *Client {
+	client := &Client{
 		ldap: client.New(),
 	}
+	client.ldap.LDAP.Logger = conf.Logger
+
+	return client
 }
 
 var _ ldapClient = (*Client)(nil)

--- a/client.go
+++ b/client.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-ldap/ldap/v3"
 	"github.com/go-ldap/ldif"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault-plugin-secrets-openldap/client"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -23,7 +24,13 @@ func NewClient(conf *logical.BackendConfig) *Client {
 	client := &Client{
 		ldap: client.New(),
 	}
-	client.ldap.LDAP.Logger = conf.Logger
+
+	logger := conf.Logger
+	if logger == nil {
+		logger = hclog.NewNullLogger()
+	}
+
+	client.ldap.LDAP.Logger = logger
 
 	return client
 }

--- a/client/client.go
+++ b/client/client.go
@@ -22,14 +22,14 @@ type Config struct {
 
 func New() Client {
 	return Client{
-		ldap: &ldaputil.Client{
+		LDAP: &ldaputil.Client{
 			LDAP: ldaputil.NewLDAP(),
 		},
 	}
 }
 
 type Client struct {
-	ldap *ldaputil.Client
+	LDAP *ldaputil.Client
 }
 
 func (c *Client) Search(cfg *Config, baseDN string, filters map[*Field][]string) ([]*Entry, error) {
@@ -40,7 +40,7 @@ func (c *Client) Search(cfg *Config, baseDN string, filters map[*Field][]string)
 		SizeLimit: math.MaxInt32,
 	}
 
-	conn, err := c.ldap.DialLDAP(cfg.ConfigEntry)
+	conn, err := c.LDAP.DialLDAP(cfg.ConfigEntry)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func (c *Client) UpdateEntry(cfg *Config, baseDN string, filters map[*Field][]st
 		modifyReq.Replace(field.String(), vals)
 	}
 
-	conn, err := c.ldap.DialLDAP(cfg.ConfigEntry)
+	conn, err := c.LDAP.DialLDAP(cfg.ConfigEntry)
 	if err != nil {
 		return err
 	}
@@ -153,7 +153,7 @@ func (c *Client) Add(cfg *Config, req *ldap.AddRequest) error {
 	if req.DN == "" {
 		return fmt.Errorf("invalid request: DN is empty")
 	}
-	conn, err := c.ldap.DialLDAP(cfg.ConfigEntry)
+	conn, err := c.LDAP.DialLDAP(cfg.ConfigEntry)
 	if err != nil {
 		return err
 	}
@@ -177,7 +177,7 @@ func (c *Client) Del(cfg *Config, req *ldap.DelRequest) error {
 	if req.DN == "" {
 		return fmt.Errorf("invalid request: DN is empty")
 	}
-	conn, err := c.ldap.DialLDAP(cfg.ConfigEntry)
+	conn, err := c.LDAP.DialLDAP(cfg.ConfigEntry)
 	if err != nil {
 		return err
 	}
@@ -195,7 +195,7 @@ func (c *Client) Execute(cfg *Config, entries []*ldif.Entry, continueOnFailure b
 		return nil
 	}
 
-	conn, err := c.ldap.DialLDAP(cfg.ConfigEntry)
+	conn, err := c.LDAP.DialLDAP(cfg.ConfigEntry)
 	if err != nil {
 		return err
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -22,7 +22,7 @@ func TestSearch(t *testing.T) {
 		LDAP:   &ldapifc.FakeLDAPClient{conn},
 	}
 
-	client := &Client{ldap: ldapClient}
+	client := &Client{LDAP: ldapClient}
 
 	filters := map[*Field][]string{
 		FieldRegistry.ObjectClass: {"*"},

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -22,7 +22,7 @@ func TestSearch(t *testing.T) {
 		LDAP:   &ldapifc.FakeLDAPClient{conn},
 	}
 
-	client := &Client{LDAP: ldapClient}
+	client := &Client{ldap: ldapClient}
 
 	filters := map[*Field][]string{
 		FieldRegistry.ObjectClass: {"*"},

--- a/client/tools/simplecall.go
+++ b/client/tools/simplecall.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault-plugin-secrets-openldap/client"
 	"github.com/hashicorp/vault/sdk/helper/ldaputil"
 )
@@ -21,7 +22,7 @@ var (
 // main executes one call using a simple client pointed at the given instance.
 func main() {
 	config := newInsecureConfig()
-	c := client.New()
+	c := client.New(hclog.NewNullLogger())
 
 	filters := map[*client.Field][]string{
 		client.FieldRegistry.DisplayName: {"Sara", "Sarah"},


### PR DESCRIPTION
We aren't passing in a logger, which can cause Vault to panic if it attempts to use a logger in the SDK `ldaputil` code.