### PR TITLE
Fixes last_bind_password client rotation retry

### DIFF
--- a/path_config.go
+++ b/path_config.go
@@ -177,6 +177,9 @@ func (b *backend) configReadOperation(ctx context.Context, req *logical.Request,
 	if config.PasswordPolicy != "" {
 		configMap["password_policy"] = config.PasswordPolicy
 	}
+	if !config.LDAP.LastBindPasswordRotation.IsZero() {
+		configMap["last_bind_password_rotation"] = config.LDAP.LastBindPasswordRotation
+	}
 
 	resp := &logical.Response{
 		Data: configMap,

--- a/path_rotate.go
+++ b/path_rotate.go
@@ -94,6 +94,8 @@ func (b *backend) pathRotateRootCredentialsUpdate(ctx context.Context, req *logi
 		return nil, err
 	}
 	config.LDAP.BindPassword = newPassword
+	config.LDAP.LastBindPassword = oldPassword
+	config.LDAP.LastBindPasswordRotation = time.Now()
 
 	// Update the password locally.
 	if pwdStoringErr := storePassword(ctx, req.Storage, config); pwdStoringErr != nil {
@@ -110,6 +112,7 @@ due to %s, configure a new binddn and bindpass to restore openldap function`, pw
 	// Respond with a 204.
 	return nil, nil
 }
+
 func (b *backend) pathRotateRoleCredentialsUpdate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	name := data.Get("name").(string)
 	if name == "" {


### PR DESCRIPTION
## Overview

This PR fixes the client retry that may occur after a root credential rotation by setting the `last_bind_password` and `last_bind_password_rotation` values. The values were not being set prior to this PR, so the retry logic would not work as expected in scenarios where an error would occur.

See [client.go#L133-L135](https://github.com/hashicorp/vault-plugin-secrets-openldap/blob/main/client/client.go#L133-L135) for where this is used.

## Testing

I added a test to this PR to ensure that the value is set after a root rotation operation.