### PR TITLE
Removes unused LDAP client interface methods

### DIFF
--- a/backend_test.go
+++ b/backend_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-ldap/ldap/v3"
 	"github.com/go-ldap/ldif"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault-plugin-secrets-openldap/client"
@@ -55,19 +54,6 @@ type fakeLdapClient struct {
 	throwErrs bool
 }
 
-func (f *fakeLdapClient) Get(_ *client.Config, _ string) (*client.Entry, error) {
-	entry := &ldap.Entry{}
-	entry.Attributes = append(entry.Attributes, &ldap.EntryAttribute{
-		Name:   client.FieldRegistry.PasswordLastSet.String(),
-		Values: []string{"131680504285591921"},
-	})
-	var err error
-	if f.throwErrs {
-		err = errors.New("forced error")
-	}
-	return client.NewEntry(entry), err
-}
-
 func (f *fakeLdapClient) UpdatePassword(_ *client.Config, _ string, _ string) error {
 	var err error
 	if f.throwErrs {
@@ -82,14 +68,6 @@ func (f *fakeLdapClient) UpdateRootPassword(_ *client.Config, _ string) error {
 		err = errors.New("forced error")
 	}
 	return err
-}
-
-func (f *fakeLdapClient) Add(_ *client.Config, _ *ldap.AddRequest) error {
-	return fmt.Errorf("not implemented")
-}
-
-func (f *fakeLdapClient) Del(_ *client.Config, _ *ldap.DelRequest) error {
-	return fmt.Errorf("not implemented")
 }
 
 func (f *fakeLdapClient) Execute(_ *client.Config, _ []*ldif.Entry, _ bool) (err error) {

--- a/client.go
+++ b/client.go
@@ -3,19 +3,14 @@ package openldap
 import (
 	"fmt"
 
-	"github.com/go-ldap/ldap/v3"
 	"github.com/go-ldap/ldif"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault-plugin-secrets-openldap/client"
 )
 
 type ldapClient interface {
-	Add(conf *client.Config, req *ldap.AddRequest) error
-	Get(conf *client.Config, dn string) (*client.Entry, error)
-	Del(conf *client.Config, req *ldap.DelRequest) error
 	UpdatePassword(conf *client.Config, dn string, newPassword string) error
 	UpdateRootPassword(conf *client.Config, newPassword string) error
-
 	Execute(conf *client.Config, entries []*ldif.Entry, continueOnError bool) (err error)
 }
 
@@ -29,25 +24,6 @@ var _ ldapClient = (*Client)(nil)
 
 type Client struct {
 	ldap client.Client
-}
-
-func (c *Client) Get(conf *client.Config, dn string) (*client.Entry, error) {
-	filters := map[*client.Field][]string{
-		client.FieldRegistry.ObjectClass: {"*"},
-	}
-
-	entries, err := c.ldap.Search(conf, dn, filters)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(entries) == 0 {
-		return nil, fmt.Errorf("unable to find entry %s in openldap", dn)
-	}
-	if len(entries) > 1 {
-		return nil, fmt.Errorf("expected one matching entry, but received %d", len(entries))
-	}
-	return entries[0], nil
 }
 
 func (c *Client) UpdatePassword(conf *client.Config, dn string, newPassword string) error {
@@ -69,14 +45,6 @@ func (c *Client) UpdateRootPassword(conf *client.Config, newPassword string) err
 	}
 
 	return c.ldap.UpdatePassword(conf, conf.BindDN, newValues, filters)
-}
-
-func (c *Client) Add(conf *client.Config, req *ldap.AddRequest) error {
-	return c.ldap.Add(conf, req)
-}
-
-func (c *Client) Del(conf *client.Config, req *ldap.DelRequest) error {
-	return c.ldap.Del(conf, req)
 }
 
 func (c *Client) Execute(conf *client.Config, entries []*ldif.Entry, continueOnError bool) (err error) {

--- a/client/client.go
+++ b/client/client.go
@@ -152,50 +152,6 @@ func shouldTryLastPwd(lastPwd string, lastBindPasswordRotation time.Time) bool {
 	return lastBindPasswordRotation.Add(10 * time.Minute).After(time.Now())
 }
 
-func (c *Client) Add(cfg *Config, req *ldap.AddRequest) error {
-	if req == nil {
-		return fmt.Errorf("invalid request: request is nil")
-	}
-	if req.DN == "" {
-		return fmt.Errorf("invalid request: DN is empty")
-	}
-	conn, err := c.ldap.DialLDAP(cfg.ConfigEntry)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-
-	if err := bind(cfg, conn); err != nil {
-		return err
-	}
-
-	err = conn.Add(req)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (c *Client) Del(cfg *Config, req *ldap.DelRequest) error {
-	if req == nil {
-		return fmt.Errorf("invalid request: request is nil")
-	}
-	if req.DN == "" {
-		return fmt.Errorf("invalid request: DN is empty")
-	}
-	conn, err := c.ldap.DialLDAP(cfg.ConfigEntry)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-
-	if err := bind(cfg, conn); err != nil {
-		return err
-	}
-
-	return conn.Del(req)
-}
-
 func (c *Client) Execute(cfg *Config, entries []*ldif.Entry, continueOnFailure bool) (err error) {
 	if len(entries) == 0 {
 		return nil

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -3,7 +3,6 @@ package openldap
 import (
 	"context"
 
-	"github.com/go-ldap/ldap/v3"
 	"github.com/go-ldap/ldif"
 	"github.com/hashicorp/vault-plugin-secrets-openldap/client"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -14,21 +13,6 @@ var _ ldapClient = (*mockLDAPClient)(nil)
 
 type mockLDAPClient struct {
 	mock.Mock
-}
-
-func (m *mockLDAPClient) Add(conf *client.Config, request *ldap.AddRequest) error {
-	args := m.Called(conf, request)
-	return args.Error(0)
-}
-
-func (m *mockLDAPClient) Get(conf *client.Config, dn string) (*client.Entry, error) {
-	args := m.Called(conf, dn)
-	return args.Get(0).(*client.Entry), args.Error(1)
-}
-
-func (m *mockLDAPClient) Del(conf *client.Config, delRequest *ldap.DelRequest) error {
-	args := m.Called(conf, delRequest)
-	return args.Error(0)
 }
 
 func (m *mockLDAPClient) UpdatePassword(conf *client.Config, dn string, newPassword string) error {


### PR DESCRIPTION
This PR removes the unused LDAP client interface methods `Add()`, `Get()`, and `Del()` to clean up the code.