### PR TITLE
Adds userattr config parameter with default based on schema

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -116,7 +116,7 @@ func TestUpdatePasswordOpenLDAP(t *testing.T) {
 		FieldRegistry.ObjectClass: {"*"},
 	}
 
-	newValues, err := GetSchemaFieldRegistry("openldap", testPass)
+	newValues, err := GetSchemaFieldRegistry(SchemaOpenLDAP, testPass)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +156,7 @@ func TestUpdatePasswordRACF(t *testing.T) {
 		FieldRegistry.ObjectClass: {"*"},
 	}
 
-	newValues, err := GetSchemaFieldRegistry("racf", testPass)
+	newValues, err := GetSchemaFieldRegistry(SchemaRACF, testPass)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -199,7 +199,7 @@ func TestUpdatePasswordAD(t *testing.T) {
 		FieldRegistry.ObjectClass: {"*"},
 	}
 
-	newValues, err := GetSchemaFieldRegistry("ad", testPass)
+	newValues, err := GetSchemaFieldRegistry(SchemaAD, testPass)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -249,7 +249,7 @@ func TestUpdateRootPassword(t *testing.T) {
 		FieldRegistry.ObjectClass: {"*"},
 	}
 
-	newValues, err := GetSchemaFieldRegistry("openldap", testPass)
+	newValues, err := GetSchemaFieldRegistry(SchemaOpenLDAP, testPass)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/schema.go
+++ b/client/schema.go
@@ -7,11 +7,17 @@ import (
 	"golang.org/x/text/encoding/unicode"
 )
 
-// SupportedSchemas returns a slice of different OpenLDAP schemas supported
-// by the plugin.  This is used to change the FieldRegistry when modifying
-// user passwords.
+const (
+	SchemaOpenLDAP = "openldap"
+	SchemaAD       = "ad"
+	SchemaRACF     = "racf"
+)
+
+// SupportedSchemas returns a slice of different LDAP schemas supported
+// by the plugin. This is used to change the FieldRegistry when modifying
+// user passwords and to set the default user attribute (userattr).
 func SupportedSchemas() []string {
-	return []string{"openldap", "racf", "ad"}
+	return []string{SchemaOpenLDAP, SchemaRACF, SchemaAD}
 }
 
 // ValidSchema checks if the configured schema is supported by the plugin.
@@ -20,20 +26,20 @@ func ValidSchema(schema string) bool {
 }
 
 // GetSchemaFieldRegistry type switches field registries depending on the configured schema.
-// For example, IBM RACF has a custom OpenLDAP schema so the password is stored in a different
+// For example, IBM RACF has a custom LDAP schema so the password is stored in a different
 // attribute.
 func GetSchemaFieldRegistry(schema string, newPassword string) (map[*Field][]string, error) {
 	switch schema {
-	case "openldap":
+	case SchemaOpenLDAP:
 		fields := map[*Field][]string{FieldRegistry.UserPassword: {newPassword}}
 		return fields, nil
-	case "racf":
+	case SchemaRACF:
 		fields := map[*Field][]string{
 			FieldRegistry.RACFPassword:   {newPassword},
 			FieldRegistry.RACFAttributes: {"noexpired"},
 		}
 		return fields, nil
-	case "ad":
+	case SchemaAD:
 		pwdEncoded, err := formatPassword(newPassword)
 		if err != nil {
 			return nil, err

--- a/path_config.go
+++ b/path_config.go
@@ -15,7 +15,7 @@ import (
 const (
 	configPath            = "config"
 	defaultPasswordLength = 64
-	defaultSchema         = "openldap"
+	defaultSchema         = client.SchemaOpenLDAP
 	defaultTLSVersion     = "tls12"
 	defaultCtxTimeout     = 1 * time.Minute
 )
@@ -39,11 +39,21 @@ func (b *backend) pathConfig() []*framework.Path {
 					Callback: b.configDeleteOperation,
 				},
 			},
-			HelpSynopsis: "Configure the OpenLDAP secret engine plugin.",
+			ExistenceCheck: b.pathConfigExistenceCheck,
+			HelpSynopsis:   "Configure the OpenLDAP secret engine plugin.",
 			HelpDescription: "This path configures the OpenLDAP secret engine plugin. See the documentation for the " +
 				"plugin specified for a full list of accepted connection details.",
 		},
 	}
+}
+
+func (b *backend) pathConfigExistenceCheck(ctx context.Context, req *logical.Request, _ *framework.FieldData) (bool, error) {
+	entry, err := readConfig(ctx, req.Storage)
+	if err != nil {
+		return false, err
+	}
+
+	return entry != nil, nil
 }
 
 func (b *backend) configFields() map[string]*framework.FieldSchema {
@@ -118,12 +128,18 @@ func (b *backend) configCreateUpdateOperation(ctx context.Context, req *logical.
 	}
 
 	if !client.ValidSchema(schema) {
-		return nil, fmt.Errorf("the configured schema %s is not valid.  Supported schemas: %s",
+		return nil, fmt.Errorf("the configured schema %s is not valid. Supported schemas: %s",
 			schema, client.SupportedSchemas())
 	}
 
-	passPolicy := fieldData.Get("password_policy").(string)
+	// Set the userattr if given. Otherwise, set the default for creates.
+	if userAttrRaw, ok := fieldData.GetOk("userattr"); ok {
+		ldapConf.UserAttr = userAttrRaw.(string)
+	} else if req.Operation == logical.CreateOperation {
+		ldapConf.UserAttr = defaultUserAttr(schema)
+	}
 
+	passPolicy := fieldData.Get("password_policy").(string)
 	if passPolicy != "" && hasPassLen {
 		// If both a password policy and a password length are set, we can't figure out what to do
 		return nil, fmt.Errorf("cannot set both 'password_policy' and 'length'")
@@ -142,6 +158,21 @@ func (b *backend) configCreateUpdateOperation(ctx context.Context, req *logical.
 
 	// Respond with a 204.
 	return nil, nil
+}
+
+// defaultUserAttr returns the default user attribute for the given
+// schema or an empty string if the schema is unknown.
+func defaultUserAttr(schema string) string {
+	switch schema {
+	case client.SchemaAD:
+		return "userPrincipalName"
+	case client.SchemaRACF:
+		return "racfid"
+	case client.SchemaOpenLDAP:
+		return "cn"
+	default:
+		return ""
+	}
 }
 
 func readConfig(ctx context.Context, storage logical.Storage) (*config, error) {
@@ -181,8 +212,7 @@ func (b *backend) configReadOperation(ctx context.Context, req *logical.Request,
 	}
 
 	// "password" is intentionally not returned by this endpoint
-	configMap := config.LDAP.Map()
-	delete(configMap, "bindpass")
+	configMap := config.LDAP.PasswordlessMap()
 	if config.PasswordLength > 0 {
 		configMap["length"] = config.PasswordLength
 	}
@@ -191,6 +221,9 @@ func (b *backend) configReadOperation(ctx context.Context, req *logical.Request,
 	}
 	if !config.LDAP.LastBindPasswordRotation.IsZero() {
 		configMap["last_bind_password_rotation"] = config.LDAP.LastBindPasswordRotation
+	}
+	if config.LDAP.Schema != "" {
+		configMap["schema"] = config.LDAP.Schema
 	}
 
 	resp := &logical.Response{


### PR DESCRIPTION
## Overview

This PR adds the `userattr` parameter to the config endpoint. Its default will be set based on the `schema` value set in the config. The `userattr` will be used to target specific LDAP user attributes in the upcoming check-in/check-out system introduced in https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/40. In this PR, it is not used for any functionality outside of being set in the config.

## Testing

I've added test cases to this PR to cover the default behavior based on the `schema` value.
