### PR TITLE
Invalidates WAL entry for static role if password policy has changed

### DIFF
--- a/backend_test.go
+++ b/backend_test.go
@@ -18,8 +18,12 @@ import (
 )
 
 var (
-	defaultLeaseTTLVal = time.Hour * 12
-	maxLeaseTTLVal     = time.Hour * 24
+	defaultLeaseTTLVal      = time.Hour * 12
+	maxLeaseTTLVal          = time.Hour * 24
+	testPasswordPolicy1     = "test_policy_1"
+	testPasswordPolicy2     = "test_policy_2"
+	testPasswordFromPolicy1 = "TestPolicy1Password"
+	testPasswordFromPolicy2 = "TestPolicy2Password"
 )
 
 func getBackend(throwsErr bool) (*backend, logical.Storage) {
@@ -29,6 +33,14 @@ func getBackend(throwsErr bool) (*backend, logical.Storage) {
 		System: &logical.StaticSystemView{
 			DefaultLeaseTTLVal: defaultLeaseTTLVal,
 			MaxLeaseTTLVal:     maxLeaseTTLVal,
+			PasswordPolicies: map[string]logical.PasswordGenerator{
+				testPasswordPolicy1: func() (string, error) {
+					return testPasswordFromPolicy1, nil
+				},
+				testPasswordPolicy2: func() (string, error) {
+					return testPasswordFromPolicy2, nil
+				},
+			},
 		},
 		StorageView: &logical.InmemStorage{},
 	}

--- a/path_static_roles_test.go
+++ b/path_static_roles_test.go
@@ -741,16 +741,29 @@ func TestWALsDeletedOnRoleDeletion(t *testing.T) {
 
 func configureOpenLDAPMount(t *testing.T, b *backend, storage logical.Storage) {
 	t.Helper()
+
+	configureOpenLDAPMountWithPasswordPolicy(t, b, storage, "")
+}
+
+func configureOpenLDAPMountWithPasswordPolicy(t *testing.T, b *backend, storage logical.Storage, policy string) {
+	t.Helper()
+
+	data := map[string]interface{}{
+		"binddn":      "tester",
+		"bindpass":    "pa$$w0rd",
+		"url":         "ldap://138.91.247.105",
+		"certificate": validCertificate,
+	}
+
+	if policy != "" {
+		data["password_policy"] = policy
+	}
+
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.CreateOperation,
 		Path:      configPath,
 		Storage:   storage,
-		Data: map[string]interface{}{
-			"binddn":      "tester",
-			"bindpass":    "pa$$w0rd",
-			"url":         "ldap://138.91.247.105",
-			"certificate": validCertificate,
-		},
+		Data:      data,
 	})
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("err:%s resp:%#v\n", err, resp)

--- a/rotation_test.go
+++ b/rotation_test.go
@@ -117,6 +117,63 @@ func TestAutoRotate(t *testing.T) {
 	})
 }
 
+// TestPasswordPolicyModificationInvalidatesWAL tests that modification of the
+// password policy set on the config invalidates pre-generated passwords in WAL
+// entries. WAL entries are used to roll forward during partial failure, but
+// a password policy change should cause the WAL to be discarded and a new
+// password to be generated using the updated policy.
+func TestPasswordPolicyModificationInvalidatesWAL(t *testing.T) {
+	ctx := context.Background()
+	b, storage := getBackend(false)
+	defer b.Cleanup(ctx)
+
+	configureOpenLDAPMountWithPasswordPolicy(t, b, storage, testPasswordPolicy1)
+	createRole(t, b, storage, "hashicorp")
+
+	// Create a WAL entry from a partial failure to rotate
+	generateWALFromFailedRotation(t, b, storage, "hashicorp")
+	requireWALs(t, storage, 1)
+
+	// The role password should still be the password generated from policy 1
+	role, err := b.staticRole(ctx, storage, "hashicorp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if role.StaticAccount.Password != testPasswordFromPolicy1 {
+		t.Fatal(role.StaticAccount.Password, testPasswordFromPolicy1)
+	}
+
+	// Update the password policy on the configuration
+	configureOpenLDAPMountWithPasswordPolicy(t, b, storage, testPasswordPolicy2)
+
+	// Manually rotate the role. It should not use the password from the WAL entry
+	// created earlier. Instead, it should result in generation of a new password
+	// using the updated policy 2.
+	_, err = b.HandleRequest(ctx, &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "rotate-role/hashicorp",
+		Storage:   storage,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The role password should be the password generated from policy 2
+	role, err = b.staticRole(ctx, storage, "hashicorp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if role.StaticAccount.Password != testPasswordFromPolicy2 {
+		t.Fatal(role.StaticAccount.Password, testPasswordFromPolicy2)
+	}
+	if role.StaticAccount.LastPassword != testPasswordFromPolicy1 {
+		t.Fatal(role.StaticAccount.Password, testPasswordFromPolicy1)
+	}
+
+	// The WAL entry should be deleted after the successful rotation
+	requireWALs(t, storage, 0)
+}
+
 func TestRollsPasswordForwardsUsingWAL(t *testing.T) {
 	ctx := context.Background()
 	b, storage := getBackend(false)

--- a/rotation_test.go
+++ b/rotation_test.go
@@ -140,7 +140,7 @@ func TestPasswordPolicyModificationInvalidatesWAL(t *testing.T) {
 		t.Fatal(err)
 	}
 	if role.StaticAccount.Password != testPasswordFromPolicy1 {
-		t.Fatal(role.StaticAccount.Password, testPasswordFromPolicy1)
+		t.Fatalf("expected %v, got %v", testPasswordFromPolicy1, role.StaticAccount.Password)
 	}
 
 	// Update the password policy on the configuration
@@ -164,10 +164,10 @@ func TestPasswordPolicyModificationInvalidatesWAL(t *testing.T) {
 		t.Fatal(err)
 	}
 	if role.StaticAccount.Password != testPasswordFromPolicy2 {
-		t.Fatal(role.StaticAccount.Password, testPasswordFromPolicy2)
+		t.Fatalf("expected %v, got %v", testPasswordFromPolicy2, role.StaticAccount.Password)
 	}
 	if role.StaticAccount.LastPassword != testPasswordFromPolicy1 {
-		t.Fatal(role.StaticAccount.Password, testPasswordFromPolicy1)
+		t.Fatalf("expected %v, got %v", testPasswordFromPolicy1, role.StaticAccount.LastPassword)
 	}
 
 	// The WAL entry should be deleted after the successful rotation


### PR DESCRIPTION
## Overview

WAL entries created by this secrets engine are the result of partial failure when trying to rotate a password for a static role. If the rotation partially fails, the system will continuously try to roll forward by reusing the password in the WAL entry. This behavior creates a problem when password constraints on the LDAP server are changed.

To give users an option to fix this, this change invalidates WAL entries for static roles when the configuration [`password_policy`](https://developer.hashicorp.com/vault/api-docs/secret/ldap#password_policy) has changed. This causes the system to generate a new password instead of reusing the WAL's password that no longer meets the constraints of the LDAP server.

Note that this only works when the named password policy has changed (say "my-policy-1" to "my-policy-2"). It doesn't solve the problem where the _contents_ of the named password policy have changed (say "my-policy-1" has a character set or length change). We don't have a good way to detect that a password policy has a new revision, so solving this for content changes is a larger effort that will involve code changes on the Vault side.

I verified that the test I wrote fails _prior_ to the change in this PR:
```sh
$ go test -run=TestPasswordPolicyModificationInvalidatesWAL
2023-03-08T08:59:40.620-0800 [INFO]  initializing database rotation queue
2023-03-08T08:59:40.620-0800 [INFO]  populating role rotation queue
2023-03-08T08:59:40.620-0800 [DEBUG] no WAL entries found
2023-03-08T08:59:40.620-0800 [INFO]  starting periodic ticker
2023-03-08T08:59:40.620-0800 [DEBUG] wrote WAL: role=hashicorp WAL ID=1cdaf653-a445-5a89-c734-bcbd92cb26ff
2023-03-08T08:59:40.620-0800 [DEBUG] deleted WAL: WAL ID=1cdaf653-a445-5a89-c734-bcbd92cb26ff
2023-03-08T08:59:40.621-0800 [DEBUG] wrote WAL: role=hashicorp WAL ID=484e20cd-72ac-d9ae-ff4c-f37f8f34de55
2023-03-08T08:59:40.621-0800 [WARN]  unable to rotate credentials in rotate-role: error="forced error"
2023-03-08T08:59:40.621-0800 [DEBUG] deleted WAL: WAL ID=484e20cd-72ac-d9ae-ff4c-f37f8f34de55
--- FAIL: TestPasswordPolicyModificationInvalidatesWAL (0.00s)
    rotation_test.go:167: expected TestPolicy2Password, got TestPolicy1Password
2023-03-08T08:59:40.621-0800 [INFO]  stopping periodic ticker
FAIL
exit status 1
FAIL    github.com/hashicorp/vault-plugin-secrets-openldap      0.220s
```

## Contributor Checklist
- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [x] Backwards compatible
