### PR TITLE
Backport 1.13.x: Invalidates WAL entry for static role if password policy has changed

### DIFF
--- a/backend_test.go
+++ b/backend_test.go
@@ -18,8 +18,12 @@ import (
 )
 
 var (
-	defaultLeaseTTLVal = time.Hour * 12
-	maxLeaseTTLVal     = time.Hour * 24
+	defaultLeaseTTLVal      = time.Hour * 12
+	maxLeaseTTLVal          = time.Hour * 24
+	testPasswordPolicy1     = "test_policy_1"
+	testPasswordPolicy2     = "test_policy_2"
+	testPasswordFromPolicy1 = "TestPolicy1Password"
+	testPasswordFromPolicy2 = "TestPolicy2Password"
 )
 
 func getBackend(throwsErr bool) (*backend, logical.Storage) {
@@ -29,6 +33,14 @@ func getBackend(throwsErr bool) (*backend, logical.Storage) {
 		System: &logical.StaticSystemView{
 			DefaultLeaseTTLVal: defaultLeaseTTLVal,
 			MaxLeaseTTLVal:     maxLeaseTTLVal,
+			PasswordPolicies: map[string]logical.PasswordGenerator{
+				testPasswordPolicy1: func() (string, error) {
+					return testPasswordFromPolicy1, nil
+				},
+				testPasswordPolicy2: func() (string, error) {
+					return testPasswordFromPolicy2, nil
+				},
+			},
 		},
 		StorageView: &logical.InmemStorage{},
 	}

--- a/path_static_roles_test.go
+++ b/path_static_roles_test.go
@@ -741,16 +741,29 @@ func TestWALsDeletedOnRoleDeletion(t *testing.T) {
 
 func configureOpenLDAPMount(t *testing.T, b *backend, storage logical.Storage) {
 	t.Helper()
+
+	configureOpenLDAPMountWithPasswordPolicy(t, b, storage, "")
+}
+
+func configureOpenLDAPMountWithPasswordPolicy(t *testing.T, b *backend, storage logical.Storage, policy string) {
+	t.Helper()
+
+	data := map[string]interface{}{
+		"binddn":      "tester",
+		"bindpass":    "pa$$w0rd",
+		"url":         "ldap://138.91.247.105",
+		"certificate": validCertificate,
+	}
+
+	if policy != "" {
+		data["password_policy"] = policy
+	}
+
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.CreateOperation,
 		Path:      configPath,
 		Storage:   storage,
-		Data: map[string]interface{}{
-			"binddn":      "tester",
-			"bindpass":    "pa$$w0rd",
-			"url":         "ldap://138.91.247.105",
-			"certificate": validCertificate,
-		},
+		Data:      data,
 	})
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("err:%s resp:%#v\n", err, resp)


### PR DESCRIPTION
This PR backports https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/56 and https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/57 into the `release/vault-1.13.x` branch.
