### PR TITLE
prevent overwriting of schema and password_policy values on update of…

### DIFF
--- a/path_config.go
+++ b/path_config.go
@@ -136,6 +136,13 @@ func (b *backend) configCreateUpdateOperation(ctx context.Context, req *logical.
 	passLength := rawPassLength.(int)
 
 	schema := fieldData.Get("schema").(string)
+	_, schemaChanged := fieldData.Raw["schema"]
+
+	// if update operation and schema not updated in raw payload, keep existing schema
+	if existing != nil && !schemaChanged {
+		schema = conf.LDAP.Schema
+	}
+
 	if schema == "" {
 		return nil, errors.New("schema is required")
 	}
@@ -153,6 +160,13 @@ func (b *backend) configCreateUpdateOperation(ctx context.Context, req *logical.
 	}
 
 	passPolicy := fieldData.Get("password_policy").(string)
+	_, passPolicyChanged := fieldData.Raw["password_policy"]
+
+	// if update operation and password_policy not updated in raw payload, keep existing password_policy
+	if existing != nil && !passPolicyChanged {
+		passPolicy = conf.PasswordPolicy
+	}
+
 	if passPolicy != "" && hasPassLen {
 		// If both a password policy and a password length are set, we can't figure out what to do
 		return nil, fmt.Errorf("cannot set both 'password_policy' and 'length'")


### PR DESCRIPTION
`password_policy` and `schema` were getting overwritten on update. 

Example:
```
# create config
vault write open/config \                                                                   
  binddn="cn=admin,dc=hashicorp,dc=com" \
  bindpass="admin" schema="ad" password_policy="3" \
  url="ldap://ldap"

# check that password_policy and schema are there
vault read open/config

# update config
vault write open/config \ 
  bindpass="admin2"

# see that password_policy is gone and schema defaults to "openldap" and not "ad"
vault read open/config
```

# Overview
A high level description of the contribution, including:
Who the change affects or is for (stakeholders)?
Anyone who updates their ldap config

What is the change?
Check to see if there is an existing value in storage for `password_policy` and `schema`. If the request does not update these properties, maintain the original values. 

Why is the change needed?
Values were getting deleted or set back to default.

How does this change affect the user experience (if at all)?

# Related Issues/Pull Requests

# Contributor Checklist
- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [ ] Backwards compatible
