### PR TITLE
Backport vault 1.13.x to stop overwrite of schema and password_policy

### DIFF
--- a/path_config.go
+++ b/path_config.go
@@ -121,6 +121,13 @@ func (b *backend) configCreateUpdateOperation(ctx context.Context, req *logical.
 	passLength := rawPassLength.(int)
 
 	schema := fieldData.Get("schema").(string)
+	_, schemaChanged := fieldData.Raw["schema"]
+
+	// if update operation and schema not updated in raw payload, keep existing schema
+	if existing != nil && !schemaChanged {
+		schema = conf.LDAP.Schema
+	}
+
 	if schema == "" {
 		return nil, errors.New("schema is required")
 	}
@@ -138,6 +145,13 @@ func (b *backend) configCreateUpdateOperation(ctx context.Context, req *logical.
 	}
 
 	passPolicy := fieldData.Get("password_policy").(string)
+	_, passPolicyChanged := fieldData.Raw["password_policy"]
+
+	// if update operation and password_policy not updated in raw payload, keep existing password_policy
+	if existing != nil && !passPolicyChanged {
+		passPolicy = conf.PasswordPolicy
+	}
+
 	if passPolicy != "" && hasPassLen {
 		// If both a password policy and a password length are set, we can't figure out what to do
 		return nil, fmt.Errorf("cannot set both 'password_policy' and 'length'")


### PR DESCRIPTION
… config (#75)

# Overview
A high level description of the contribution, including:
Who the change affects or is for (stakeholders)?
What is the change?
Why is the change needed?
How does this change affect the user experience (if at all)?

# Related Issues/Pull Requests
- [ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
- [ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [ ] Backwards compatible
