### PR TITLE
support ad rotate-root with userattr="userPrincipalName"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 ### IMPROVEMENTS:
-* add rotate-root support for when using userattr=userPrincipalName
+* add rotate-root support when using userattr=userPrincipalName
  
 ## v0.11.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### IMPROVEMENTS:
+* add rotate-root support for when using userattr=userPrincipalName
+ 
 ## v0.11.1
 
 ### IMPROVEMENTS:

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,110 @@
+package openldap
+
+import (
+	"testing"
+
+	"github.com/go-ldap/ldap/v3"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/sdk/helper/ldaputil"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hashicorp/vault-plugin-secrets-openldap/client"
+	"github.com/hashicorp/vault-plugin-secrets-openldap/ldapifc"
+)
+
+func GetTestClient(fake *ldapifc.FakeLDAPConnection) *Client {
+	ldapClient := client.NewWithClient(hclog.NewNullLogger(), &ldapifc.FakeLDAPClient{
+		ConnToReturn: fake,
+	})
+
+	return &Client{ldap: ldapClient}
+}
+
+// UpdateDNPassword when the UserAttr is "userPrincipalName"
+func Test_UpdateDNPassword_AD_UserPrincipalName(t *testing.T) {
+	newPassword := "newpassword"
+	conn := &ldapifc.FakeLDAPConnection{
+		ModifyRequestToExpect: &ldap.ModifyRequest{
+			DN: "CN=Bob,CN=Users,DC=example,DC=net",
+		},
+		SearchRequestToExpect: &ldap.SearchRequest{
+			BaseDN: "cn=users",
+			Scope:  ldap.ScopeWholeSubtree,
+			Filter: "(&(objectClass=*)(userPrincipalName=bob@example.net))",
+		},
+		SearchResultToReturn: &ldap.SearchResult{
+			Entries: []*ldap.Entry{
+				{
+					DN: "CN=Bob,CN=Users,DC=example,DC=net",
+				},
+			},
+		},
+	}
+
+	c := GetTestClient(conn)
+	config := &client.Config{
+		ConfigEntry: &ldaputil.ConfigEntry{
+			Url:          "ldaps://ldap:386",
+			UserDN:       "cn=users",
+			UPNDomain:    "example.net",
+			UserAttr:     "userPrincipalName",
+			BindDN:       "username",
+			BindPassword: "password",
+		},
+		Schema: client.SchemaAD,
+	}
+
+	// depending on the schema, the password may be formatted, so we leverage this helper function
+	fields, err := client.GetSchemaFieldRegistry(config.Schema, newPassword)
+	assert.NoError(t, err)
+	for k, v := range fields {
+		conn.ModifyRequestToExpect.Replace(k.String(), v)
+	}
+
+	err = c.UpdateDNPassword(config, "bob", newPassword)
+	assert.NoError(t, err)
+}
+
+// UpdateDNPassword when the UserAttr is "dn"
+func Test_UpdateDNPassword_AD_DN(t *testing.T) {
+	newPassword := "newpassword"
+	conn := &ldapifc.FakeLDAPConnection{
+		ModifyRequestToExpect: &ldap.ModifyRequest{
+			DN: "CN=Bob,CN=Users,DC=example,DC=net",
+		},
+		SearchRequestToExpect: &ldap.SearchRequest{
+			BaseDN: "CN=Bob,CN=Users,DC=example,DC=net",
+			Scope:  ldap.ScopeBaseObject,
+			Filter: "(objectClass=*)",
+		},
+		SearchResultToReturn: &ldap.SearchResult{
+			Entries: []*ldap.Entry{
+				{
+					DN: "CN=Bob,CN=Users,DC=example,DC=net",
+				},
+			},
+		},
+	}
+
+	c := GetTestClient(conn)
+	config := &client.Config{
+		ConfigEntry: &ldaputil.ConfigEntry{
+			Url:          "ldaps://ldap:386",
+			UserAttr:     "dn",
+			BindDN:       "username",
+			BindPassword: "password",
+		},
+		Schema: client.SchemaAD,
+	}
+
+	// depending on the schema, the password may be formatted, so we leverage this helper function
+	fields, err := client.GetSchemaFieldRegistry(config.Schema, newPassword)
+	assert.NoError(t, err)
+	for k, v := range fields {
+		conn.ModifyRequestToExpect.Replace(k.String(), v)
+	}
+
+	err = c.UpdateDNPassword(config, "CN=Bob,CN=Users,DC=example,DC=net", newPassword)
+	assert.NoError(t, err)
+
+}


### PR DESCRIPTION
# Overview

Supports rotate-root when ldap is configured with `userattr="userPrincipalName"`.
When setting both a `userattr` and a `upndomain` in the config, previous versions of the secrets engine would error out, since it expected a full DN. With this change, we now correctly can perform searches against the specified `userattr`.

```
vault write ldap/config \
    url="ldap://localhost:389" \
    userdn="dc=corp,dc=example,dc=net" \
    userattr="userPrincipalName" \
    upndomain="corp.example.net" \
    insecure_tls="true" \
    binddn="Bob" \
    schema=ad \
    starttls=true
Success! Data written to: ldap/config


vault write -f ldap/rotate-root
Success! Data written to: ldap/rotate-root
```

In the above example, the secrets engine will apply a search filter `dc=corp,dc=example,dc=net` as the baseDN, and a search filter of `(&(objectClass=*)(userPrincipalName=Bob@corp.example.net))`

Also tested other variations manually:
*  `schema=openldap`
* `schema=ad` && `userattr=dn`