### PR TITLE
add hierarchical path handling to static role endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@
 REPO_DIR := $(shell basename $(CURDIR))
 
 PLUGIN_NAME := $(shell command ls cmd/)
+ifndef $(GOPATH)
+    GOPATH=$(shell go env GOPATH)
+    export GOPATH
+endif
 PLUGIN_DIR ?= $$GOPATH/vault-plugins
 PLUGIN_PATH ?= local-secrets-ldap
 

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ fmt:
 	gofumpt -l -w .
 
 configure: dev
-	@./bootstrap/configure.sh \
+	./bootstrap/configure.sh \
 	$(PLUGIN_DIR) \
 	$(PLUGIN_NAME) \
 	$(PLUGIN_PATH)

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 REPO_DIR := $(shell basename $(CURDIR))
 
 PLUGIN_NAME := $(shell command ls cmd/)
+PLUGIN_DIR ?= $$GOPATH/vault-plugins
+PLUGIN_PATH ?= local-secrets-ldap
 
 .PHONY: default
 default: dev
@@ -41,3 +43,9 @@ fmtcheck:
 .PHONY: fmt
 fmt:
 	gofumpt -l -w .
+
+configure: dev
+	@./bootstrap/configure.sh \
+	$(PLUGIN_DIR) \
+	$(PLUGIN_NAME) \
+	$(PLUGIN_PATH)

--- a/bootstrap/configure.sh
+++ b/bootstrap/configure.sh
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 

--- a/bootstrap/configure.sh
+++ b/bootstrap/configure.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+PLUGIN_DIR=$1
+PLUGIN_NAME=$2
+PLUGIN_PATH=$3
+
+echo "==> PLUGIN_DIR: $PLUGIN_DIR"
+echo "==> PLUGIN_NAME: $PLUGIN_NAME"
+echo "==> PLUGIN_PATH: $PLUGIN_PATH"
+
+# Try to clean-up previous runs
+vault secrets disable "${PLUGIN_PATH}"
+vault plugin deregister secret "${PLUGIN_NAME}"
+killall "${PLUGIN_NAME}"
+
+# Copy the binary so text file is not busy when rebuilding & the plugin is registered
+cp ./bin/"$PLUGIN_NAME" "$PLUGIN_DIR"
+
+# Sets up the binary with local changes
+vault plugin register \
+    -sha256="$(shasum -a 256 "$PLUGIN_DIR"/"$PLUGIN_NAME" | awk '{print $1}')" \
+    -version="0.0.1" \
+    secret "${PLUGIN_NAME}"
+
+if [ -e scripts/custom.sh ]
+then
+  . scripts/custom.sh
+fi
+

--- a/path_rotate.go
+++ b/path_rotate.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/vault/sdk/framework"
@@ -48,7 +49,7 @@ func (b *backend) pathRotateCredentials() []*framework.Path {
 				"(binddn) used by Vault to manage LDAP.",
 		},
 		{
-			Pattern: rotateRolePath + framework.GenericNameRegex("name"),
+			Pattern: strings.TrimSuffix(rotateRolePath, "/") + GenericNameWithForwardSlashRegex("name"),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixLDAP,
 				OperationVerb:   "rotate",

--- a/path_rotate.go
+++ b/path_rotate.go
@@ -49,7 +49,7 @@ func (b *backend) pathRotateCredentials() []*framework.Path {
 				"(binddn) used by Vault to manage LDAP.",
 		},
 		{
-			Pattern: strings.TrimSuffix(rotateRolePath, "/") + GenericNameWithForwardSlashRegex("name"),
+			Pattern: strings.TrimSuffix(rotateRolePath, "/") + genericNameWithForwardSlashRegex("name"),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixLDAP,
 				OperationVerb:   "rotate",

--- a/path_rotate_test.go
+++ b/path_rotate_test.go
@@ -95,7 +95,7 @@ func TestManualRotateRole(t *testing.T) {
 		configureOpenLDAPMount(t, b, storage)
 		createRole(t, b, storage, roleName)
 
-		resp, _ := readStaticCred(t, b, storage, roleName)
+		resp := readStaticCred(t, b, storage, roleName)
 
 		if resp.Data["password"] == "" {
 			t.Fatal("expected password to be set, it wasn't")
@@ -114,7 +114,7 @@ func TestManualRotateRole(t *testing.T) {
 			t.Fatalf("err:%s resp:%#v\n", err, resp)
 		}
 
-		resp, _ = readStaticCred(t, b, storage, roleName)
+		resp = readStaticCred(t, b, storage, roleName)
 
 		if resp.Data["password"] == "" {
 			t.Fatal("expected password to be set after rotate, it wasn't")
@@ -142,7 +142,7 @@ func TestManualRotateRole(t *testing.T) {
 		passwords := make([]string, 0)
 		// rotate all the creds
 		for _, role := range roles {
-			resp, _ := readStaticCred(t, b, storage, role)
+			resp := readStaticCred(t, b, storage, role)
 
 			if resp.Data["password"] == "" {
 				t.Fatal("expected password to be set, it wasn't")
@@ -161,7 +161,7 @@ func TestManualRotateRole(t *testing.T) {
 				t.Fatalf("err:%s resp:%#v\n", err, resp)
 			}
 
-			resp, _ = readStaticCred(t, b, storage, role)
+			resp = readStaticCred(t, b, storage, role)
 
 			newPassword := resp.Data["password"]
 			if newPassword == "" {

--- a/path_rotate_test.go
+++ b/path_rotate_test.go
@@ -10,14 +10,15 @@ import (
 	"time"
 
 	"github.com/go-ldap/ldif"
+	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/hashicorp/vault-plugin-secrets-openldap/client"
 	"github.com/hashicorp/vault/sdk/helper/ldaputil"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestManualRotate(t *testing.T) {
-	t.Run("rotate root", func(t *testing.T) {
+func TestManualRotateRoot(t *testing.T) {
+	t.Run("happy path rotate root", func(t *testing.T) {
 		b, storage := getBackend(false)
 		defer b.Cleanup(context.Background())
 
@@ -83,23 +84,29 @@ func TestManualRotate(t *testing.T) {
 			t.Fatal("should have got error, didn't")
 		}
 	})
+}
 
-	t.Run("rotate role", func(t *testing.T) {
+func TestManualRotateRole(t *testing.T) {
+	t.Run("happy path rotate role", func(t *testing.T) {
 		b, storage := getBackend(false)
 		defer b.Cleanup(context.Background())
 
-		data := map[string]interface{}{
-			"binddn":      "tester",
-			"bindpass":    "pa$$w0rd",
-			"url":         "ldap://138.91.247.105",
-			"certificate": validCertificate,
+		roleName := "hashicorp"
+		configureOpenLDAPMount(t, b, storage)
+		createRole(t, b, storage, roleName)
+
+		resp, _ := readStaticCred(t, b, storage, roleName)
+
+		if resp.Data["password"] == "" {
+			t.Fatal("expected password to be set, it wasn't")
 		}
+		oldPassword := resp.Data["password"]
 
 		req := &logical.Request{
-			Operation: logical.CreateOperation,
-			Path:      configPath,
+			Operation: logical.UpdateOperation,
+			Path:      rotateRolePath + roleName,
 			Storage:   storage,
-			Data:      data,
+			Data:      nil,
 		}
 
 		resp, err := b.HandleRequest(context.Background(), req)
@@ -107,76 +114,7 @@ func TestManualRotate(t *testing.T) {
 			t.Fatalf("err:%s resp:%#v\n", err, resp)
 		}
 
-		req = &logical.Request{
-			Operation: logical.UpdateOperation,
-			Path:      rotateRootPath,
-			Storage:   storage,
-			Data:      nil,
-		}
-
-		resp, err = b.HandleRequest(context.Background(), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
-
-		data = map[string]interface{}{
-			"username":        "hashicorp",
-			"dn":              "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
-			"rotation_period": "60s",
-		}
-
-		req = &logical.Request{
-			Operation: logical.CreateOperation,
-			Path:      staticRolePath + "hashicorp",
-			Storage:   storage,
-			Data:      data,
-		}
-
-		resp, err = b.HandleRequest(context.Background(), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
-
-		req = &logical.Request{
-			Operation: logical.ReadOperation,
-			Path:      staticCredPath + "hashicorp",
-			Storage:   storage,
-			Data:      nil,
-		}
-
-		resp, err = b.HandleRequest(context.Background(), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
-
-		if resp.Data["password"] == "" {
-			t.Fatal("expected password to be set, it wasn't")
-		}
-		oldPassword := resp.Data["password"]
-
-		req = &logical.Request{
-			Operation: logical.UpdateOperation,
-			Path:      rotateRolePath + "hashicorp",
-			Storage:   storage,
-			Data:      nil,
-		}
-
-		resp, err = b.HandleRequest(context.Background(), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
-
-		req = &logical.Request{
-			Operation: logical.ReadOperation,
-			Path:      staticCredPath + "hashicorp",
-			Storage:   storage,
-			Data:      nil,
-		}
-
-		resp, err = b.HandleRequest(context.Background(), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
+		resp, _ = readStaticCred(t, b, storage, roleName)
 
 		if resp.Data["password"] == "" {
 			t.Fatal("expected password to be set after rotate, it wasn't")
@@ -184,6 +122,61 @@ func TestManualRotate(t *testing.T) {
 
 		if oldPassword == resp.Data["password"] {
 			t.Fatal("expected passwords to be different after rotation, they weren't")
+		}
+	})
+
+	t.Run("happy path rotate role with hierarchical path", func(t *testing.T) {
+		b, storage := getBackend(false)
+		defer b.Cleanup(context.Background())
+
+		configureOpenLDAPMount(t, b, storage)
+
+		roles := []string{"org/secure", "org/platform/dev", "org/platform/support"}
+
+		// create all the roles
+		for _, role := range roles {
+			data := getTestStaticRoleConfig(role)
+			createStaticRoleWithData(t, b, storage, role, data)
+		}
+
+		passwords := make([]string, 0)
+		// rotate all the creds
+		for _, role := range roles {
+			resp, _ := readStaticCred(t, b, storage, role)
+
+			if resp.Data["password"] == "" {
+				t.Fatal("expected password to be set, it wasn't")
+			}
+			oldPassword := resp.Data["password"]
+
+			req := &logical.Request{
+				Operation: logical.UpdateOperation,
+				Path:      rotateRolePath + role,
+				Storage:   storage,
+				Data:      nil,
+			}
+
+			resp, err := b.HandleRequest(context.Background(), req)
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("err:%s resp:%#v\n", err, resp)
+			}
+
+			resp, _ = readStaticCred(t, b, storage, role)
+
+			newPassword := resp.Data["password"]
+			if newPassword == "" {
+				t.Fatal("expected password to be set after rotate, it wasn't")
+			}
+
+			if oldPassword == newPassword {
+				t.Fatal("expected passwords to be different after rotation, they weren't")
+			}
+			passwords = append(passwords, newPassword.(string))
+		}
+
+		// extra pendantic check that the hierarchical paths don't return the same data
+		if len(passwords) != len(strutil.RemoveDuplicates(passwords, false)) {
+			t.Fatal("expected unique static-role paths to return unique passwords")
 		}
 	})
 
@@ -284,7 +277,6 @@ func TestRollbackPassword(t *testing.T) {
 			}
 			assert.Equal(t, testCase.expectedPassword, fclient.password)
 			assert.Equal(t, testCase.expectedRollbackCalls, fclient.count)
-
 		})
 	}
 }

--- a/path_static_creds.go
+++ b/path_static_creds.go
@@ -16,7 +16,7 @@ const staticCredPath = "static-cred/"
 func (b *backend) pathStaticCredsCreate() []*framework.Path {
 	return []*framework.Path{
 		{
-			Pattern: strings.TrimSuffix(staticCredPath, "/") + GenericNameWithForwardSlashRegex("name"),
+			Pattern: strings.TrimSuffix(staticCredPath, "/") + genericNameWithForwardSlashRegex("name"),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixLDAP,
 				OperationVerb:   "request",

--- a/path_static_creds.go
+++ b/path_static_creds.go
@@ -5,6 +5,7 @@ package openldap
 
 import (
 	"context"
+	"strings"
 
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -15,7 +16,7 @@ const staticCredPath = "static-cred/"
 func (b *backend) pathStaticCredsCreate() []*framework.Path {
 	return []*framework.Path{
 		{
-			Pattern: staticCredPath + framework.GenericNameRegex("name"),
+			Pattern: strings.TrimSuffix(staticCredPath, "/") + GenericNameWithForwardSlashRegex("name"),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixLDAP,
 				OperationVerb:   "request",

--- a/path_static_creds_test.go
+++ b/path_static_creds_test.go
@@ -84,7 +84,7 @@ func assertReadStaticCred(t *testing.T, b *backend, storage logical.Storage, rol
 	t.Helper()
 	resp := readStaticCred(t, b, storage, roleName)
 
-	if resp.Data["dn"] != data["dn"] {
+	if resp.Data["dn"] != data["dn"] && data["dn"] != nil {
 		t.Fatalf("expected dn to be %s but got %s", data["dn"], resp.Data["dn"])
 	}
 
@@ -92,7 +92,7 @@ func assertReadStaticCred(t *testing.T, b *backend, storage logical.Storage, rol
 		t.Fatal("expected password to be set, it wasn't")
 	}
 
-	if resp.Data["username"] != data["username"] {
+	if resp.Data["username"] != data["username"] && data["username"] != nil {
 		t.Fatalf("expected username to be %s but got %s", data["username"], resp.Data["username"])
 	}
 

--- a/path_static_creds_test.go
+++ b/path_static_creds_test.go
@@ -14,90 +14,39 @@ func TestCreds(t *testing.T) {
 	t.Run("happy path with creds", func(t *testing.T) {
 		b, storage := getBackend(false)
 		defer b.Cleanup(context.Background())
+		configureOpenLDAPMount(t, b, storage)
 
 		data := map[string]interface{}{
-			"binddn":      "tester",
-			"bindpass":    "pa$$w0rd",
-			"url":         "ldap://138.91.247.105",
-			"certificate": validCertificate,
-		}
-
-		req := &logical.Request{
-			Operation: logical.CreateOperation,
-			Path:      configPath,
-			Storage:   storage,
-			Data:      data,
-		}
-
-		resp, err := b.HandleRequest(context.Background(), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
-
-		data = map[string]interface{}{
 			"username":        "hashicorp",
 			"dn":              "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
-			"rotation_period": "60s",
+			"rotation_period": float64(60),
 		}
 
-		req = &logical.Request{
-			Operation: logical.CreateOperation,
-			Path:      staticRolePath + "hashicorp",
-			Storage:   storage,
-			Data:      data,
+		roleName := "hashicorp"
+		createStaticRoleWithData(t, b, storage, roleName, data)
+		assertReadStaticCred(t, b, storage, roleName, data)
+	})
+
+	t.Run("happy path with hierarchical cred path", func(t *testing.T) {
+		b, storage := getBackend(false)
+		defer b.Cleanup(context.Background())
+		configureOpenLDAPMount(t, b, storage)
+
+		roles := []string{"org/secure", "org/platform/dev", "org/platform/support"}
+
+		// create all the roles
+		for _, role := range roles {
+			data := getTestStaticRoleConfig(role)
+			resp, err := createStaticRoleWithData(t, b, storage, role, data)
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("err:%s resp:%#v\n", err, resp)
+			}
 		}
 
-		resp, err = b.HandleRequest(context.Background(), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
-
-		req = &logical.Request{
-			Operation: logical.ReadOperation,
-			Path:      staticRolePath + "hashicorp",
-			Storage:   storage,
-			Data:      nil,
-		}
-
-		resp, err = b.HandleRequest(context.Background(), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
-
-		req = &logical.Request{
-			Operation: logical.ReadOperation,
-			Path:      staticCredPath + "hashicorp",
-			Storage:   storage,
-			Data:      nil,
-		}
-
-		resp, err = b.HandleRequest(context.Background(), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
-
-		if resp.Data["dn"] == "" {
-			t.Fatal("expected dn to be set, it wasn't")
-		}
-
-		if resp.Data["password"] == "" {
-			t.Fatal("expected password to be set, it wasn't")
-		}
-
-		if resp.Data["username"] == "" {
-			t.Fatal("expected username to be set, it wasn't")
-		}
-
-		if resp.Data["last_vault_rotation"] == nil {
-			t.Fatal("expected last_vault_rotation to be set, it wasn't")
-		}
-
-		if resp.Data["rotation_period"] != float64(60) {
-			t.Fatalf("expected rotation_period to be %f, got %f", float64(60), resp.Data["rotation_period"])
-		}
-
-		if resp.Data["ttl"] == nil {
-			t.Fatal("expected ttl to be set, it wasn't")
+		// read all the creds
+		for _, role := range roles {
+			data := getTestStaticRoleConfig(role)
+			assertReadStaticCred(t, b, storage, role, data)
 		}
 	})
 
@@ -105,14 +54,7 @@ func TestCreds(t *testing.T) {
 		b, storage := getBackend(false)
 		defer b.Cleanup(context.Background())
 
-		req := &logical.Request{
-			Operation: logical.ReadOperation,
-			Path:      staticCredPath + "hashicorp",
-			Storage:   storage,
-			Data:      nil,
-		}
-
-		resp, err := b.HandleRequest(context.Background(), req)
+		resp, err := readStaticCred(t, b, storage, "hashicorp")
 		if err != nil {
 			t.Fatalf("error reading cred: %s", err)
 		}
@@ -120,4 +62,48 @@ func TestCreds(t *testing.T) {
 			t.Fatal("expected error")
 		}
 	})
+}
+
+func readStaticCred(t *testing.T, b *backend, storage logical.Storage, roleName string) (*logical.Response, error) {
+	req := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      staticCredPath + roleName,
+		Storage:   storage,
+		Data:      nil,
+	}
+
+	return b.HandleRequest(context.Background(), req)
+}
+
+func assertReadStaticCred(t *testing.T, b *backend, storage logical.Storage, roleName string, data map[string]interface{}) {
+	t.Helper()
+	resp, err := readStaticCred(t, b, storage, roleName)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+	if resp.Data["dn"] != data["dn"] {
+		t.Fatalf("expected dn to be %s but got %s", data["dn"], resp.Data["dn"])
+	}
+
+	if resp.Data["password"] == "" {
+		t.Fatal("expected password to be set, it wasn't")
+	}
+
+	if resp.Data["username"] != data["username"] {
+		t.Fatalf("expected username to be %s but got %s", data["username"], resp.Data["username"])
+	}
+
+	if resp.Data["last_vault_rotation"] == nil {
+		t.Fatal("expected last_vault_rotation to be set, it wasn't")
+	}
+
+	expected := data["rotation_period"].(float64)
+	if resp.Data["rotation_period"] != expected {
+		t.Fatalf("expected rotation_period to be %f but got %s", expected, resp.Data["rotation_period"])
+	}
+
+	if resp.Data["ttl"] == nil {
+		t.Fatal("expected ttl to be set, it wasn't")
+	}
 }

--- a/path_static_roles.go
+++ b/path_static_roles.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -20,10 +21,23 @@ const (
 	staticRolePath = "static-role/"
 )
 
+// RolePathRegex is a regex which requires a role name. The role name
+// can include any number of characters separated by forward slashes.
+func RolePathRegex(name string) string {
+	return fmt.Sprintf("(/(?P<%s>.+))", name)
+}
+
+// RoleListRegex is a regex for optionally including a role path in
+// list options. The role path can be used to list nested roles at
+// arbitrary depth.
+func RoleListRegex(name string) string {
+	return fmt.Sprintf("/?(/(?P<%s>.+/))?", name)
+}
+
 func (b *backend) pathListStaticRoles() []*framework.Path {
 	return []*framework.Path{
 		{
-			Pattern: staticRolePath + "?$",
+			Pattern: strings.TrimSuffix(staticRolePath, "/") + RoleListRegex("path"),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixLDAP,
 				OperationVerb:   "list",
@@ -32,6 +46,12 @@ func (b *backend) pathListStaticRoles() []*framework.Path {
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ListOperation: &framework.PathOperation{
 					Callback: b.pathStaticRoleList,
+				},
+			},
+			Fields: map[string]*framework.FieldSchema{
+				"path": {
+					Type:        framework.TypeLowerCaseString,
+					Description: "Path of roles to list",
 				},
 			},
 			HelpSynopsis:    staticRolesListHelpSynopsis,
@@ -43,7 +63,7 @@ func (b *backend) pathListStaticRoles() []*framework.Path {
 func (b *backend) pathStaticRoles() []*framework.Path {
 	return []*framework.Path{
 		{
-			Pattern: staticRolePath + framework.GenericNameRegex("name"),
+			Pattern: strings.TrimSuffix(staticRolePath, "/") + RolePathRegex("name"),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixLDAP,
 				OperationSuffix: "static-role",
@@ -438,7 +458,8 @@ func (s *staticAccount) PasswordTTL() time.Duration {
 }
 
 func (b *backend) pathStaticRoleList(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	roles, err := req.Storage.List(ctx, staticRolePath)
+	rolePath := data.Get("path").(string)
+	roles, err := req.Storage.List(ctx, staticRolePath+rolePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list roles: %w", err)
 	}

--- a/path_static_roles.go
+++ b/path_static_roles.go
@@ -31,6 +31,7 @@ func GenericNameWithForwardSlashRegex(name string) string {
 // role path in list options. The role path can be used to list nested roles at
 // arbitrary depth.
 func OptionalGenericNameWithForwardSlashListRegex(name string) string {
+	// TODO(JM): List regex should support optional trailing slash
 	return fmt.Sprintf("/?(/(?P<%s>.+/))?", name)
 }
 

--- a/path_static_roles.go
+++ b/path_static_roles.go
@@ -21,16 +21,16 @@ const (
 	staticRolePath = "static-role/"
 )
 
-// GenericNameWithForwardSlashRegex is a regex which requires a role name. The role name can
-// include any number of alphanumberic characters separated by forward slashes.
-func GenericNameWithForwardSlashRegex(name string) string {
-	return fmt.Sprintf("(/(?P<%s>\\w(([\\w-./]+)?\\w)?))", name)
+// genericNameWithForwardSlashRegex is a regex which requires a role name. The role name can
+// include any number of alphanumeric characters separated by forward slashes.
+func genericNameWithForwardSlashRegex(name string) string {
+	return fmt.Sprintf(`(/(?P<%s>\w(([\w-./]+)?\w)?))`, name)
 }
 
-// OptionalGenericNameWithForwardSlashListRegex is a regex for optionally including a
+// optionalGenericNameWithForwardSlashListRegex is a regex for optionally including a
 // role path in list options. The role path can be used to list nested roles at
 // arbitrary depth.
-func OptionalGenericNameWithForwardSlashListRegex(name string) string {
+func optionalGenericNameWithForwardSlashListRegex(name string) string {
 	// TODO(JM): List regex should support optional trailing slash
 	return fmt.Sprintf("/?(/(?P<%s>.+/))?", name)
 }
@@ -38,7 +38,7 @@ func OptionalGenericNameWithForwardSlashListRegex(name string) string {
 func (b *backend) pathListStaticRoles() []*framework.Path {
 	return []*framework.Path{
 		{
-			Pattern: strings.TrimSuffix(staticRolePath, "/") + OptionalGenericNameWithForwardSlashListRegex("path"),
+			Pattern: strings.TrimSuffix(staticRolePath, "/") + optionalGenericNameWithForwardSlashListRegex("path"),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixLDAP,
 				OperationVerb:   "list",
@@ -64,7 +64,7 @@ func (b *backend) pathListStaticRoles() []*framework.Path {
 func (b *backend) pathStaticRoles() []*framework.Path {
 	return []*framework.Path{
 		{
-			Pattern: strings.TrimSuffix(staticRolePath, "/") + GenericNameWithForwardSlashRegex("name"),
+			Pattern: strings.TrimSuffix(staticRolePath, "/") + genericNameWithForwardSlashRegex("name"),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixLDAP,
 				OperationSuffix: "static-role",

--- a/path_static_roles.go
+++ b/path_static_roles.go
@@ -21,23 +21,23 @@ const (
 	staticRolePath = "static-role/"
 )
 
-// RolePathRegex is a regex which requires a role name. The role name
-// can include any number of characters separated by forward slashes.
-func RolePathRegex(name string) string {
-	return fmt.Sprintf("(/(?P<%s>.+))", name)
+// GenericNameWithForwardSlashRegex is a regex which requires a role name. The role name can
+// include any number of alphanumberic characters separated by forward slashes.
+func GenericNameWithForwardSlashRegex(name string) string {
+	return fmt.Sprintf("(/(?P<%s>\\w(([\\w-./]+)?\\w)?))", name)
 }
 
-// RoleListRegex is a regex for optionally including a role path in
-// list options. The role path can be used to list nested roles at
+// OptionalGenericNameWithForwardSlashListRegex is a regex for optionally including a
+// role path in list options. The role path can be used to list nested roles at
 // arbitrary depth.
-func RoleListRegex(name string) string {
+func OptionalGenericNameWithForwardSlashListRegex(name string) string {
 	return fmt.Sprintf("/?(/(?P<%s>.+/))?", name)
 }
 
 func (b *backend) pathListStaticRoles() []*framework.Path {
 	return []*framework.Path{
 		{
-			Pattern: strings.TrimSuffix(staticRolePath, "/") + RoleListRegex("path"),
+			Pattern: strings.TrimSuffix(staticRolePath, "/") + OptionalGenericNameWithForwardSlashListRegex("path"),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixLDAP,
 				OperationVerb:   "list",
@@ -63,7 +63,7 @@ func (b *backend) pathListStaticRoles() []*framework.Path {
 func (b *backend) pathStaticRoles() []*framework.Path {
 	return []*framework.Path{
 		{
-			Pattern: strings.TrimSuffix(staticRolePath, "/") + RolePathRegex("name"),
+			Pattern: strings.TrimSuffix(staticRolePath, "/") + GenericNameWithForwardSlashRegex("name"),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixLDAP,
 				OperationSuffix: "static-role",

--- a/path_static_roles_test.go
+++ b/path_static_roles_test.go
@@ -214,29 +214,6 @@ func Test_backend_pathStaticRoleLifecycle(t *testing.T) {
 }
 
 func TestRoles(t *testing.T) {
-	t.Run("happy path with hierarchical role path", func(t *testing.T) {
-		b, storage := getBackend(false)
-		defer b.Cleanup(context.Background())
-
-		configureOpenLDAPMount(t, b, storage)
-
-		roles := []string{"org/secure", "org/platform/dev", "org/platform/support"}
-
-		// create all the roles
-		for _, role := range roles {
-			data := getTestStaticRoleConfig(role)
-			resp, err := createStaticRoleWithData(t, b, storage, role, data)
-			if err != nil || (resp != nil && resp.IsError()) {
-				t.Fatalf("err:%s resp:%#v\n", err, resp)
-			}
-		}
-
-		// read all the roles
-		for _, role := range roles {
-			data := getTestStaticRoleConfig(role)
-			assertReadStaticRole(t, b, storage, role, data)
-		}
-	})
 	t.Run("happy path with role using DN search", func(t *testing.T) {
 		b, storage := getBackend(false)
 		defer b.Cleanup(context.Background())
@@ -430,6 +407,30 @@ func TestRoles(t *testing.T) {
 		}
 		if resp != nil {
 			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("happy path with hierarchical role path", func(t *testing.T) {
+		b, storage := getBackend(false)
+		defer b.Cleanup(context.Background())
+
+		configureOpenLDAPMount(t, b, storage)
+
+		roles := []string{"org/secure", "org/platform/dev", "org/platform/support"}
+
+		// create all the roles
+		for _, role := range roles {
+			data := getTestStaticRoleConfig(role)
+			resp, err := createStaticRoleWithData(t, b, storage, role, data)
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("err:%s resp:%#v\n", err, resp)
+			}
+		}
+
+		// read all the roles
+		for _, role := range roles {
+			data := getTestStaticRoleConfig(role)
+			assertReadStaticRole(t, b, storage, role, data)
 		}
 	})
 }

--- a/path_static_roles_test.go
+++ b/path_static_roles_test.go
@@ -221,17 +221,10 @@ func TestRoles(t *testing.T) {
 		configureOpenLDAPMount(t, b, storage)
 
 		roles := []string{"org/secure", "org/platform/dev", "org/platform/support"}
-		getData := func(name string) map[string]interface{} {
-			return map[string]interface{}{
-				"username":        name,
-				"dn":              "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
-				"rotation_period": float64(5),
-			}
-		}
 
 		// create all the roles
 		for _, role := range roles {
-			data := getData(role)
+			data := getTestStaticRoleConfig(role)
 			resp, err := createStaticRoleWithData(t, b, storage, role, data)
 			if err != nil || (resp != nil && resp.IsError()) {
 				t.Fatalf("err:%s resp:%#v\n", err, resp)
@@ -240,7 +233,7 @@ func TestRoles(t *testing.T) {
 
 		// read all the roles
 		for _, role := range roles {
-			data := getData(role)
+			data := getTestStaticRoleConfig(role)
 			assertReadStaticRole(t, b, storage, role, data)
 		}
 	})
@@ -494,17 +487,10 @@ func TestListRoles(t *testing.T) {
 		configureOpenLDAPMount(t, b, storage)
 
 		roles := []string{"org/secure", "org/platform/dev", "org/platform/support"}
-		getData := func(name string) map[string]interface{} {
-			return map[string]interface{}{
-				"username":        name,
-				"dn":              "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
-				"rotation_period": float64(5),
-			}
-		}
 
 		// create all the roles
 		for _, role := range roles {
-			data := getData(role)
+			data := getTestStaticRoleConfig(role)
 			resp, err := createStaticRoleWithData(t, b, storage, role, data)
 			if err != nil || (resp != nil && resp.IsError()) {
 				t.Fatalf("err:%s resp:%#v\n", err, resp)
@@ -734,5 +720,13 @@ func assertReadStaticRole(t *testing.T, b *backend, storage logical.Storage, rol
 
 	if resp.Data["last_vault_rotation"] == nil {
 		t.Fatal("expected last_vault_rotation to not be empty")
+	}
+}
+
+func getTestStaticRoleConfig(name string) map[string]interface{} {
+	return map[string]interface{}{
+		"username":        name,
+		"dn":              "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
+		"rotation_period": float64(5),
 	}
 }


### PR DESCRIPTION
This PR adds hierarchical path handling to the following APIs:
- [Static roles](https://developer.hashicorp.com/vault/api-docs/secret/ldap#static-roles)
- [Static role passwords](https://developer.hashicorp.com/vault/api-docs/secret/ldap#static-role-passwords)
- [Manually rotate static role password](https://developer.hashicorp.com/vault/api-docs/secret/ldap#manually-rotate-static-role-password)

This allows creating a static role name with an arbitrary number of forward slashes. For example,

```
$ vault write ldap/static-role/org/platform/dev \
    username="user3" \
    rotation_period="5m"
```

Where `org/platform/dev` is the role name. Creds can be read and rotated using the same role name and the respective API's. For example,

```
$ vault read ldap/static-cred/org/secure
Key                    Value
---                    -----
dn                     n/a
last_password          a3sQ6OkmXKt2dtx22kAt36YLkkxLsg4RmhMZCLYCBCbvvv67ILROaOokdCaGPEAE
last_vault_rotation    2024-05-03T16:39:27.174164-05:00
password               ECf7ZoxfDxGuJEYZrzgzTffSIDI4tx5TojBR9wuEGp8bqUXbl4Kr9eAgPjmizcvg
rotation_period        5m
ttl                    4m58s
username               user2

$ vault write -f ldap/rotate-role/org/secure
```

Most importantly, this allows us to perform LIST operations to query the available roles. For example,

```
$ vault list ldap/static-role/org/
Keys
----
platform/
secure

$ vault list ldap/static-role/org/platform
Keys
----
dev
```