### PR TITLE
enable hierarchical path for dynamic roles and creds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@
 REPO_DIR := $(shell basename $(CURDIR))
 
 PLUGIN_NAME := $(shell command ls cmd/)
+ifndef $(GOPATH)
+    GOPATH=$(shell go env GOPATH)
+    export GOPATH
+endif
 PLUGIN_DIR ?= $$GOPATH/vault-plugins
 PLUGIN_PATH ?= local-secrets-ldap
 

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ fmt:
 	gofumpt -l -w .
 
 configure: dev
-	@./bootstrap/configure.sh \
+	./bootstrap/configure.sh \
 	$(PLUGIN_DIR) \
 	$(PLUGIN_NAME) \
 	$(PLUGIN_PATH)

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 REPO_DIR := $(shell basename $(CURDIR))
 
 PLUGIN_NAME := $(shell command ls cmd/)
+PLUGIN_DIR ?= $$GOPATH/vault-plugins
+PLUGIN_PATH ?= local-secrets-ldap
 
 .PHONY: default
 default: dev
@@ -41,3 +43,9 @@ fmtcheck:
 .PHONY: fmt
 fmt:
 	gofumpt -l -w .
+
+configure: dev
+	@./bootstrap/configure.sh \
+	$(PLUGIN_DIR) \
+	$(PLUGIN_NAME) \
+	$(PLUGIN_PATH)

--- a/backend_test.go
+++ b/backend_test.go
@@ -6,7 +6,6 @@ package openldap
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/go-ldap/ldif"
@@ -85,8 +84,12 @@ func (f *fakeLdapClient) UpdateDNPassword(_ *client.Config, _ string, _ string) 
 	return err
 }
 
-func (f *fakeLdapClient) Execute(_ *client.Config, _ []*ldif.Entry, _ bool) (err error) {
-	return fmt.Errorf("not implemented")
+func (f *fakeLdapClient) Execute(_ *client.Config, _ []*ldif.Entry, _ bool) error {
+	var err error
+	if f.throwErrs {
+		err = errors.New("forced error")
+	}
+	return err
 }
 
 const validCertificate = `

--- a/bootstrap/configure.sh
+++ b/bootstrap/configure.sh
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 

--- a/bootstrap/configure.sh
+++ b/bootstrap/configure.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+PLUGIN_DIR=$1
+PLUGIN_NAME=$2
+PLUGIN_PATH=$3
+
+echo "==> PLUGIN_DIR: $PLUGIN_DIR"
+echo "==> PLUGIN_NAME: $PLUGIN_NAME"
+echo "==> PLUGIN_PATH: $PLUGIN_PATH"
+
+# Try to clean-up previous runs
+vault secrets disable "${PLUGIN_PATH}"
+vault plugin deregister secret "${PLUGIN_NAME}"
+killall "${PLUGIN_NAME}"
+
+# Copy the binary so text file is not busy when rebuilding & the plugin is registered
+cp ./bin/"$PLUGIN_NAME" "$PLUGIN_DIR"
+
+# Sets up the binary with local changes
+vault plugin register \
+    -sha256="$(shasum -a 256 "$PLUGIN_DIR"/"$PLUGIN_NAME" | awk '{print $1}')" \
+    -version="0.0.1" \
+    secret "${PLUGIN_NAME}"
+
+if [ -e scripts/custom.sh ]
+then
+  . scripts/custom.sh
+fi
+

--- a/path_dynamic_creds.go
+++ b/path_dynamic_creds.go
@@ -6,6 +6,7 @@ package openldap
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-ldap/ldif"
@@ -21,7 +22,7 @@ import (
 func (b *backend) pathDynamicCredsCreate() []*framework.Path {
 	return []*framework.Path{
 		{
-			Pattern: dynamicCredPath + framework.GenericNameRegex("name"),
+			Pattern: strings.TrimSuffix(dynamicCredPath, "/") + GenericNameWithForwardSlashRegex("name"),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixLDAP,
 				OperationVerb:   "request",

--- a/path_dynamic_creds.go
+++ b/path_dynamic_creds.go
@@ -22,7 +22,7 @@ import (
 func (b *backend) pathDynamicCredsCreate() []*framework.Path {
 	return []*framework.Path{
 		{
-			Pattern: strings.TrimSuffix(dynamicCredPath, "/") + GenericNameWithForwardSlashRegex("name"),
+			Pattern: strings.TrimSuffix(dynamicCredPath, "/") + genericNameWithForwardSlashRegex("name"),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixLDAP,
 				OperationVerb:   "request",

--- a/path_dynamic_creds_test.go
+++ b/path_dynamic_creds_test.go
@@ -368,6 +368,46 @@ func TestDynamicCredsRead_success(t *testing.T) {
 	}
 }
 
+func TestDynamicCredsRead_success_hierarchicalRolePath(t *testing.T) {
+	t.Run("list dynamic roles with hierarchical role path", func(t *testing.T) {
+		b, storage := getBackend(false)
+		defer b.Cleanup(context.Background())
+		configureOpenLDAPMount(t, b, storage)
+
+		roles := []string{"org/secure", "org/platform/dev", "org/platform/support"}
+
+		// create all the roles
+		for _, role := range roles {
+			data := getTestDynamicRoleConfig(role)
+			resp, err := createDynamicRoleWithData(t, b, storage, role, data)
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("err:%s resp:%#v\n", err, resp)
+			}
+		}
+
+		// read all the creds
+		for _, rolePath := range roles {
+			req := &logical.Request{
+				Operation: logical.ReadOperation,
+				Path:      dynamicCredPath + rolePath,
+				Storage:   storage,
+			}
+			resp, err := b.HandleRequest(context.Background(), req)
+			require.NoError(t, err)
+
+			username := getStringT(t, resp.Data, "username")
+			require.NotEmpty(t, username)
+			require.Contains(t, username, rolePath)
+
+			password := getStringT(t, resp.Data, "password")
+			require.NotEmpty(t, password)
+
+			dns := getStringSlice(t, resp.Data, "distinguished_names")
+			require.Len(t, dns, 1)
+		}
+	})
+}
+
 func TestSecretCredsRenew(t *testing.T) {
 	roleName := "testrole"
 	now := time.Now()

--- a/path_dynamic_roles.go
+++ b/path_dynamic_roles.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"path"
+	"strings"
 	"time"
 
 	"github.com/go-ldap/ldif"
@@ -27,7 +27,7 @@ const (
 func (b *backend) pathDynamicRoles() []*framework.Path {
 	return []*framework.Path{
 		{
-			Pattern: path.Join(dynamicRolePath, framework.GenericNameRegex("name")),
+			Pattern: strings.TrimSuffix(dynamicRolePath, "/") + GenericNameWithForwardSlashRegex("name"),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixLDAP,
 				OperationSuffix: "dynamic-role",
@@ -84,11 +84,17 @@ func (b *backend) pathDynamicRoles() []*framework.Path {
 			HelpDescription: staticRoleHelpDescription,
 		},
 		{
-			Pattern: dynamicRolePath + "?$",
+			Pattern: strings.TrimSuffix(dynamicRolePath, "/") + OptionalGenericNameWithForwardSlashListRegex("path"),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixLDAP,
 				OperationVerb:   "list",
 				OperationSuffix: "dynamic-roles",
+			},
+			Fields: map[string]*framework.FieldSchema{
+				"path": {
+					Type:        framework.TypeLowerCaseString,
+					Description: "Path of roles to list",
+				},
 			},
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ListOperation: &framework.PathOperation{
@@ -286,7 +292,8 @@ func (b *backend) pathDynamicRoleRead(ctx context.Context, req *logical.Request,
 }
 
 func (b *backend) pathDynamicRoleList(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	roles, err := req.Storage.List(ctx, dynamicRolePath)
+	rolePath := data.Get("path").(string)
+	roles, err := req.Storage.List(ctx, dynamicRolePath+rolePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list roles: %w", err)
 	}

--- a/path_dynamic_roles.go
+++ b/path_dynamic_roles.go
@@ -27,7 +27,7 @@ const (
 func (b *backend) pathDynamicRoles() []*framework.Path {
 	return []*framework.Path{
 		{
-			Pattern: strings.TrimSuffix(dynamicRolePath, "/") + GenericNameWithForwardSlashRegex("name"),
+			Pattern: strings.TrimSuffix(dynamicRolePath, "/") + genericNameWithForwardSlashRegex("name"),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixLDAP,
 				OperationSuffix: "dynamic-role",
@@ -84,7 +84,7 @@ func (b *backend) pathDynamicRoles() []*framework.Path {
 			HelpDescription: staticRoleHelpDescription,
 		},
 		{
-			Pattern: strings.TrimSuffix(dynamicRolePath, "/") + OptionalGenericNameWithForwardSlashListRegex("path"),
+			Pattern: strings.TrimSuffix(dynamicRolePath, "/") + optionalGenericNameWithForwardSlashListRegex("path"),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixLDAP,
 				OperationVerb:   "list",

--- a/path_dynamic_roles_test.go
+++ b/path_dynamic_roles_test.go
@@ -253,9 +253,7 @@ func TestDynamicRoleCreateUpdate(t *testing.T) {
 				Storage:   storage,
 			}
 
-			// ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			ctx := context.Background()
-			// defer cancel()
 
 			_, err := b.pathDynamicRoleCreateUpdate(ctx, req, test.createData)
 			if test.expectErr && err == nil {
@@ -287,7 +285,7 @@ func TestDynamicRole_partialUpdate(t *testing.T) {
 				"creation_ldif":     ldifCreationTemplate,
 				"deletion_ldif":     ldifDeleteTemplate,
 				"rollback_ldif":     ldifRollbackTemplate,
-				"username_template": "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				"username_template": "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				"default_ttl":       "10s",
 				"max_ttl":           "1m",
 			},
@@ -296,7 +294,7 @@ func TestDynamicRole_partialUpdate(t *testing.T) {
 				CreationLDIF:     ldifCreationTemplate,
 				DeletionLDIF:     ldifDeleteTemplate,
 				RollbackLDIF:     ldifRollbackTemplate,
-				UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				DefaultTTL:       10 * time.Second,
 				MaxTTL:           1 * time.Minute,
 			},
@@ -310,7 +308,7 @@ func TestDynamicRole_partialUpdate(t *testing.T) {
 				CreationLDIF:     ldifCreationTemplate,
 				DeletionLDIF:     ldifDeleteTemplate,
 				RollbackLDIF:     ldifRollbackTemplate,
-				UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				DefaultTTL:       30 * time.Second,
 				MaxTTL:           1 * time.Minute,
 			},
@@ -322,7 +320,7 @@ func TestDynamicRole_partialUpdate(t *testing.T) {
 				"creation_ldif":     ldifCreationTemplate,
 				"deletion_ldif":     ldifDeleteTemplate,
 				"rollback_ldif":     ldifRollbackTemplate,
-				"username_template": "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				"username_template": "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				"default_ttl":       "10s",
 				"max_ttl":           "1m",
 			},
@@ -331,7 +329,7 @@ func TestDynamicRole_partialUpdate(t *testing.T) {
 				CreationLDIF:     ldifCreationTemplate,
 				DeletionLDIF:     ldifDeleteTemplate,
 				RollbackLDIF:     ldifRollbackTemplate,
-				UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				DefaultTTL:       10 * time.Second,
 				MaxTTL:           1 * time.Minute,
 			},
@@ -345,7 +343,7 @@ func TestDynamicRole_partialUpdate(t *testing.T) {
 				CreationLDIF:     ldifCreationTemplate,
 				DeletionLDIF:     ldifDeleteTemplate,
 				RollbackLDIF:     ldifRollbackTemplate,
-				UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				DefaultTTL:       10 * time.Second,
 				MaxTTL:           2 * time.Minute,
 			},
@@ -357,7 +355,7 @@ func TestDynamicRole_partialUpdate(t *testing.T) {
 				"creation_ldif":     ldifCreationTemplate,
 				"deletion_ldif":     ldifDeleteTemplate,
 				"rollback_ldif":     ldifRollbackTemplate,
-				"username_template": "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				"username_template": "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				"default_ttl":       "10s",
 				"max_ttl":           "1m",
 			},
@@ -366,7 +364,7 @@ func TestDynamicRole_partialUpdate(t *testing.T) {
 				CreationLDIF:     ldifCreationTemplate,
 				DeletionLDIF:     ldifDeleteTemplate,
 				RollbackLDIF:     ldifRollbackTemplate,
-				UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				DefaultTTL:       10 * time.Second,
 				MaxTTL:           1 * time.Minute,
 			},
@@ -392,7 +390,7 @@ memberOf: cn=dev,ou=groups,dc=hashicorp,dc=com
 userPassword: {{.Password}}`,
 				DeletionLDIF:     ldifDeleteTemplate,
 				RollbackLDIF:     ldifRollbackTemplate,
-				UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				DefaultTTL:       10 * time.Second,
 				MaxTTL:           1 * time.Minute,
 			},
@@ -404,7 +402,7 @@ userPassword: {{.Password}}`,
 				"creation_ldif":     ldifCreationTemplate,
 				"deletion_ldif":     ldifDeleteTemplate,
 				"rollback_ldif":     ldifRollbackTemplate,
-				"username_template": "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				"username_template": "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				"default_ttl":       "10s",
 				"max_ttl":           "1m",
 			},
@@ -413,7 +411,7 @@ userPassword: {{.Password}}`,
 				CreationLDIF:     ldifCreationTemplate,
 				DeletionLDIF:     ldifDeleteTemplate,
 				RollbackLDIF:     ldifRollbackTemplate,
-				UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				DefaultTTL:       10 * time.Second,
 				MaxTTL:           1 * time.Minute,
 			},
@@ -429,7 +427,7 @@ changetype: delete`,
 				DeletionLDIF: `dn: cn={{.Username | lowercase}},ou=users,dc=learn,dc=example
 changetype: delete`,
 				RollbackLDIF:     ldifRollbackTemplate,
-				UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				DefaultTTL:       10 * time.Second,
 				MaxTTL:           1 * time.Minute,
 			},
@@ -441,7 +439,7 @@ changetype: delete`,
 				"creation_ldif":     ldifCreationTemplate,
 				"deletion_ldif":     ldifDeleteTemplate,
 				"rollback_ldif":     ldifRollbackTemplate,
-				"username_template": "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				"username_template": "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				"default_ttl":       "10s",
 				"max_ttl":           "1m",
 			},
@@ -450,7 +448,7 @@ changetype: delete`,
 				CreationLDIF:     ldifCreationTemplate,
 				DeletionLDIF:     ldifDeleteTemplate,
 				RollbackLDIF:     ldifRollbackTemplate,
-				UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				DefaultTTL:       10 * time.Second,
 				MaxTTL:           1 * time.Minute,
 			},
@@ -466,7 +464,7 @@ changetype: delete`,
 				DeletionLDIF: ldifDeleteTemplate,
 				RollbackLDIF: `dn: cn={{.Username | lowercase}},ou=users,dc=learn,dc=example
 changetype: delete`,
-				UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				DefaultTTL:       10 * time.Second,
 				MaxTTL:           1 * time.Minute,
 			},
@@ -478,7 +476,7 @@ changetype: delete`,
 				"creation_ldif":     ldifCreationTemplate,
 				"deletion_ldif":     ldifDeleteTemplate,
 				"rollback_ldif":     ldifRollbackTemplate,
-				"username_template": "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				"username_template": "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				"default_ttl":       "10s",
 				"max_ttl":           "1m",
 			},
@@ -487,21 +485,21 @@ changetype: delete`,
 				CreationLDIF:     ldifCreationTemplate,
 				DeletionLDIF:     ldifDeleteTemplate,
 				RollbackLDIF:     ldifRollbackTemplate,
-				UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				DefaultTTL:       10 * time.Second,
 				MaxTTL:           1 * time.Minute,
 			},
 
 			updateData: map[string]interface{}{
 				"name":              roleName,
-				"username_template": "v.{{.RoleName | lowercase}}.{{rand 10}}",
+				"username_template": "v.{{.RoleName | lowercase}}.{{random 10}}",
 			},
 			updateRole: &dynamicRole{
 				Name:             roleName,
 				CreationLDIF:     ldifCreationTemplate,
 				DeletionLDIF:     ldifDeleteTemplate,
 				RollbackLDIF:     ldifRollbackTemplate,
-				UsernameTemplate: "v.{{.RoleName | lowercase}}.{{rand 10}}",
+				UsernameTemplate: "v.{{.RoleName | lowercase}}.{{random 10}}",
 				DefaultTTL:       10 * time.Second,
 				MaxTTL:           1 * time.Minute,
 			},
@@ -513,7 +511,7 @@ changetype: delete`,
 				"creation_ldif":     ldifCreationTemplate,
 				"deletion_ldif":     ldifDeleteTemplate,
 				"rollback_ldif":     ldifRollbackTemplate,
-				"username_template": "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				"username_template": "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				"default_ttl":       "10s",
 				"max_ttl":           "1m",
 			},
@@ -522,7 +520,7 @@ changetype: delete`,
 				CreationLDIF:     ldifCreationTemplate,
 				DeletionLDIF:     ldifDeleteTemplate,
 				RollbackLDIF:     ldifRollbackTemplate,
-				UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				DefaultTTL:       10 * time.Second,
 				MaxTTL:           1 * time.Minute,
 			},
@@ -536,7 +534,7 @@ changetype: delete`,
 				CreationLDIF:     ldifCreationTemplate,
 				DeletionLDIF:     ldifDeleteTemplate,
 				RollbackLDIF:     ldifRollbackTemplate,
-				UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				DefaultTTL:       10 * time.Second,
 				MaxTTL:           1 * time.Minute,
 			},
@@ -548,7 +546,7 @@ changetype: delete`,
 				"creation_ldif":     ldifCreationTemplate,
 				"deletion_ldif":     ldifDeleteTemplate,
 				"rollback_ldif":     ldifRollbackTemplate,
-				"username_template": "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				"username_template": "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				"default_ttl":       "10s",
 				"max_ttl":           "1m",
 			},
@@ -557,7 +555,7 @@ changetype: delete`,
 				CreationLDIF:     ldifCreationTemplate,
 				DeletionLDIF:     ldifDeleteTemplate,
 				RollbackLDIF:     ldifRollbackTemplate,
-				UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				DefaultTTL:       10 * time.Second,
 				MaxTTL:           1 * time.Minute,
 			},
@@ -571,7 +569,7 @@ changetype: delete`,
 				CreationLDIF:     ldifCreationTemplate,
 				DeletionLDIF:     ldifDeleteTemplate,
 				RollbackLDIF:     ldifRollbackTemplate,
-				UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				DefaultTTL:       10 * time.Second,
 				MaxTTL:           1 * time.Minute,
 			},
@@ -583,7 +581,7 @@ changetype: delete`,
 				"creation_ldif":     ldifCreationTemplate,
 				"deletion_ldif":     ldifDeleteTemplate,
 				"rollback_ldif":     ldifRollbackTemplate,
-				"username_template": "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				"username_template": "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				"default_ttl":       "10s",
 				"max_ttl":           "1m",
 			},
@@ -592,7 +590,7 @@ changetype: delete`,
 				CreationLDIF:     ldifCreationTemplate,
 				DeletionLDIF:     ldifDeleteTemplate,
 				RollbackLDIF:     ldifRollbackTemplate,
-				UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				DefaultTTL:       10 * time.Second,
 				MaxTTL:           1 * time.Minute,
 			},
@@ -606,7 +604,7 @@ changetype: delete`,
 				CreationLDIF:     ldifCreationTemplate,
 				DeletionLDIF:     ldifDeleteTemplate,
 				RollbackLDIF:     "",
-				UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				DefaultTTL:       10 * time.Second,
 				MaxTTL:           1 * time.Minute,
 			},
@@ -618,7 +616,7 @@ changetype: delete`,
 				"creation_ldif":     ldifCreationTemplate,
 				"deletion_ldif":     ldifDeleteTemplate,
 				"rollback_ldif":     ldifRollbackTemplate,
-				"username_template": "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				"username_template": "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				"default_ttl":       "10s",
 				"max_ttl":           "1m",
 			},
@@ -627,7 +625,7 @@ changetype: delete`,
 				CreationLDIF:     ldifCreationTemplate,
 				DeletionLDIF:     ldifDeleteTemplate,
 				RollbackLDIF:     ldifRollbackTemplate,
-				UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				DefaultTTL:       10 * time.Second,
 				MaxTTL:           1 * time.Minute,
 			},
@@ -653,7 +651,7 @@ changetype: delete`,
 				"creation_ldif":     ldifCreationTemplate,
 				"deletion_ldif":     ldifDeleteTemplate,
 				"rollback_ldif":     ldifRollbackTemplate,
-				"username_template": "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				"username_template": "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				"default_ttl":       "10s",
 				"max_ttl":           "1m",
 			},
@@ -662,7 +660,7 @@ changetype: delete`,
 				CreationLDIF:     ldifCreationTemplate,
 				DeletionLDIF:     ldifDeleteTemplate,
 				RollbackLDIF:     ldifRollbackTemplate,
-				UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				DefaultTTL:       10 * time.Second,
 				MaxTTL:           1 * time.Minute,
 			},
@@ -676,7 +674,7 @@ changetype: delete`,
 				CreationLDIF:     ldifCreationTemplate,
 				DeletionLDIF:     ldifDeleteTemplate,
 				RollbackLDIF:     ldifRollbackTemplate,
-				UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				DefaultTTL:       0,
 				MaxTTL:           1 * time.Minute,
 			},
@@ -688,7 +686,7 @@ changetype: delete`,
 				"creation_ldif":     ldifCreationTemplate,
 				"deletion_ldif":     ldifDeleteTemplate,
 				"rollback_ldif":     ldifRollbackTemplate,
-				"username_template": "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				"username_template": "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				"default_ttl":       "10s",
 				"max_ttl":           "1m",
 			},
@@ -697,7 +695,7 @@ changetype: delete`,
 				CreationLDIF:     ldifCreationTemplate,
 				DeletionLDIF:     ldifDeleteTemplate,
 				RollbackLDIF:     ldifRollbackTemplate,
-				UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				DefaultTTL:       10 * time.Second,
 				MaxTTL:           1 * time.Minute,
 			},
@@ -711,7 +709,7 @@ changetype: delete`,
 				CreationLDIF:     ldifCreationTemplate,
 				DeletionLDIF:     ldifDeleteTemplate,
 				RollbackLDIF:     ldifRollbackTemplate,
-				UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				DefaultTTL:       0,
 				MaxTTL:           1 * time.Minute,
 			},
@@ -723,7 +721,7 @@ changetype: delete`,
 				"creation_ldif":     ldifCreationTemplate,
 				"deletion_ldif":     ldifDeleteTemplate,
 				"rollback_ldif":     ldifRollbackTemplate,
-				"username_template": "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				"username_template": "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				"default_ttl":       "10s",
 				"max_ttl":           "1m",
 			},
@@ -732,7 +730,7 @@ changetype: delete`,
 				CreationLDIF:     ldifCreationTemplate,
 				DeletionLDIF:     ldifDeleteTemplate,
 				RollbackLDIF:     ldifRollbackTemplate,
-				UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				DefaultTTL:       10 * time.Second,
 				MaxTTL:           1 * time.Minute,
 			},
@@ -746,7 +744,7 @@ changetype: delete`,
 				CreationLDIF:     ldifCreationTemplate,
 				DeletionLDIF:     ldifDeleteTemplate,
 				RollbackLDIF:     ldifRollbackTemplate,
-				UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				DefaultTTL:       10 * time.Second,
 				MaxTTL:           0,
 			},
@@ -758,7 +756,7 @@ changetype: delete`,
 				"creation_ldif":     ldifCreationTemplate,
 				"deletion_ldif":     ldifDeleteTemplate,
 				"rollback_ldif":     ldifRollbackTemplate,
-				"username_template": "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				"username_template": "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				"default_ttl":       "10s",
 				"max_ttl":           "1m",
 			},
@@ -767,7 +765,7 @@ changetype: delete`,
 				CreationLDIF:     ldifCreationTemplate,
 				DeletionLDIF:     ldifDeleteTemplate,
 				RollbackLDIF:     ldifRollbackTemplate,
-				UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				DefaultTTL:       10 * time.Second,
 				MaxTTL:           1 * time.Minute,
 			},
@@ -781,7 +779,7 @@ changetype: delete`,
 				CreationLDIF:     ldifCreationTemplate,
 				DeletionLDIF:     ldifDeleteTemplate,
 				RollbackLDIF:     ldifRollbackTemplate,
-				UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+				UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 				DefaultTTL:       10 * time.Second,
 				MaxTTL:           0,
 			},
@@ -798,33 +796,12 @@ changetype: delete`,
 
 			storage := &logical.InmemStorage{}
 
-			// Find the creation endpoint & use its schema
-			var schema map[string]*framework.FieldSchema
-			for _, endpoint := range b.pathDynamicRoles() {
-				if endpoint.Pattern != path.Join(dynamicRolePath, framework.GenericNameRegex("name")) {
-					continue
-				}
-				if _, exists := endpoint.Operations[logical.CreateOperation]; !exists {
-					continue
-				}
-				schema = endpoint.Fields
-			}
-
-			initialData := &framework.FieldData{
-				Raw:    test.initialData,
-				Schema: schema,
-			}
-
-			req := &logical.Request{
-				Storage: storage,
-			}
-
 			// Shared context, but with timeout to ensure the test ends
 			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 			defer cancel()
 
 			// Save original version
-			resp, err := b.pathDynamicRoleCreateUpdate(ctx, req, initialData)
+			resp, err := createDynamicRoleWithData(t, b, storage, roleName, test.initialData)
 			require.NoError(t, err)
 			require.Nil(t, resp)
 
@@ -832,12 +809,7 @@ changetype: delete`,
 			require.NoError(t, err)
 			require.Equal(t, test.initialRole, actualRole)
 
-			// Update to new version
-			updateData := &framework.FieldData{
-				Raw:    test.updateData,
-				Schema: schema,
-			}
-			resp, err = b.pathDynamicRoleCreateUpdate(ctx, req, updateData)
+			resp, err = updateDynamicRoleWithData(t, b, storage, roleName, test.updateData)
 			if test.expectErr && err == nil {
 				t.Fatalf("err expected, got nil")
 			}
@@ -885,7 +857,7 @@ func TestDynamicRoleRead(t *testing.T) {
 					CreationLDIF:     ldifCreationTemplate,
 					RollbackLDIF:     ldifRollbackTemplate,
 					DeletionLDIF:     ldifDeleteTemplate,
-					UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+					UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 					DefaultTTL:       24 * time.Hour,
 					MaxTTL:           5 * 24 * time.Hour,
 				}),
@@ -896,7 +868,7 @@ func TestDynamicRoleRead(t *testing.T) {
 					"creation_ldif":     ldifCreationTemplate,
 					"rollback_ldif":     ldifRollbackTemplate,
 					"deletion_ldif":     ldifDeleteTemplate,
-					"username_template": "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+					"username_template": "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 					"default_ttl":       (24 * time.Hour).Seconds(),
 					"max_ttl":           (5 * 24 * time.Hour).Seconds(),
 				},
@@ -941,72 +913,45 @@ func TestDynamicRoleRead(t *testing.T) {
 }
 
 func TestDynamicRoleList(t *testing.T) {
-	type testCase struct {
-		storageResp []string
-		storageErr  error
+	t.Run("list dynamic roles with hierarchical role path", func(t *testing.T) {
+		b, storage := getBackend(false)
+		defer b.Cleanup(context.Background())
 
-		expectedResp *logical.Response
-		expectErr    bool
-	}
+		configureOpenLDAPMount(t, b, storage)
 
-	tests := map[string]testCase{
-		"storage failure": {
-			storageResp:  nil,
-			storageErr:   fmt.Errorf("test error"),
-			expectedResp: nil,
-			expectErr:    true,
-		},
-		"happy path": {
-			storageResp: []string{
-				"foo",
-				"bar",
-				"baz",
-			},
-			storageErr: nil,
-			expectedResp: &logical.Response{
-				Data: map[string]interface{}{
-					"keys": []string{
-						"foo",
-						"bar",
-						"baz",
-					},
-				},
-			},
-			expectErr: false,
-		},
-	}
+		roles := []string{"org/secure", "org/platform/dev", "org/platform/support"}
 
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			client := new(mockLDAPClient)
-			defer client.AssertExpectations(t) // No expectations
+		// create all the roles
+		for _, role := range roles {
+			data := getTestDynamicRoleConfig(role)
+			resp, err := createDynamicRoleWithData(t, b, storage, role, data)
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("err:%s resp:%#v\n", err, resp)
+			}
+		}
 
-			b := Backend(client)
-
-			storage := new(mockStorage)
-			storage.On("List", mock.Anything, dynamicRolePath).
-				Return(test.storageResp, test.storageErr)
-			defer storage.AssertNumberOfCalls(t, "List", 1)
-
+		// TODO(JM): List regex should support optional trailing slash
+		// rolePaths := []string{"org", "org/", "org/platform", "org/platform/"}
+		rolePaths := []string{"org/", "org/platform/"}
+		for _, rolePath := range rolePaths {
 			req := &logical.Request{
-				Storage: storage,
+				Operation: logical.ListOperation,
+				Path:      dynamicRolePath + rolePath,
+				Storage:   storage,
+				Data:      nil,
 			}
-			data := dynamicRoleFieldData(map[string]interface{}{})
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-			defer cancel()
+			resp, err := b.HandleRequest(context.Background(), req)
 
-			resp, err := b.pathDynamicRoleList(ctx, req, data)
-			if test.expectErr && err == nil {
-				t.Fatalf("err expected, got nil")
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("path: %s, err:%s resp:%#v\n", rolePath, err, resp)
 			}
-			if !test.expectErr && err != nil {
-				t.Fatalf("no error expected, got: %s", err)
+
+			keys := resp.Data["keys"].([]string)
+			if len(keys) != 2 {
+				t.Fatalf("expected list with %d keys, got %d", 2, len(keys))
 			}
-			if !reflect.DeepEqual(resp, test.expectedResp) {
-				t.Fatalf("Actual response: %#v\nExpected response: %#v", resp, test.expectedResp)
-			}
-		})
-	}
+		}
+	})
 }
 
 func TestDynamicRoleExistenceCheck(t *testing.T) {
@@ -1045,7 +990,7 @@ cn: learn
 sn: learn
 memberOf: cn=dev,ou=groups,dc=hashicorp,dc=com
 userPassword: {{.Password}}`,
-					UsernameTemplate: "v-foo-{{.RoleName}}-{{rand 20}}-{{unix_seconds}}",
+					UsernameTemplate: "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
 					DefaultTTL:       24 * time.Hour,
 					MaxTTL:           5 * 24 * time.Hour,
 				}),
@@ -1227,6 +1172,53 @@ func TestConvertToDuration(t *testing.T) {
 			}
 		})
 	}
+}
+
+func listDynamicRole(t *testing.T, b *backend, s logical.Storage, name string) (*logical.Response, error) {
+	t.Helper()
+	req := &logical.Request{
+		Operation: logical.ListOperation,
+		Path:      dynamicRolePath + name,
+		Storage:   s,
+	}
+
+	return b.HandleRequest(context.Background(), req)
+}
+
+func getTestDynamicRoleConfig(name string) map[string]interface{} {
+	return map[string]interface{}{
+		"name":              name,
+		"creation_ldif":     ldifCreationTemplate,
+		"deletion_ldif":     ldifDeleteTemplate,
+		"rollback_ldif":     ldifRollbackTemplate,
+		"username_template": "v-foo-{{.RoleName}}-{{random 20}}-{{unix_time}}",
+		"default_ttl":       "10s",
+		"max_ttl":           "1m",
+	}
+}
+
+func createDynamicRoleWithData(t *testing.T, b *backend, s logical.Storage, name string, d map[string]interface{}) (*logical.Response, error) {
+	t.Helper()
+	req := &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      dynamicRolePath + name,
+		Storage:   s,
+		Data:      d,
+	}
+
+	return b.HandleRequest(context.Background(), req)
+}
+
+func updateDynamicRoleWithData(t *testing.T, b *backend, s logical.Storage, name string, d map[string]interface{}) (*logical.Response, error) {
+	t.Helper()
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      dynamicRolePath + name,
+		Storage:   s,
+		Data:      d,
+	}
+
+	return b.HandleRequest(context.Background(), req)
 }
 
 func dynamicRoleFieldData(data map[string]interface{}) *framework.FieldData {

--- a/path_rotate.go
+++ b/path_rotate.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/vault/sdk/framework"
@@ -48,7 +49,7 @@ func (b *backend) pathRotateCredentials() []*framework.Path {
 				"(binddn) used by Vault to manage LDAP.",
 		},
 		{
-			Pattern: rotateRolePath + framework.GenericNameRegex("name"),
+			Pattern: strings.TrimSuffix(rotateRolePath, "/") + GenericNameWithForwardSlashRegex("name"),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixLDAP,
 				OperationVerb:   "rotate",

--- a/path_rotate.go
+++ b/path_rotate.go
@@ -49,7 +49,7 @@ func (b *backend) pathRotateCredentials() []*framework.Path {
 				"(binddn) used by Vault to manage LDAP.",
 		},
 		{
-			Pattern: strings.TrimSuffix(rotateRolePath, "/") + GenericNameWithForwardSlashRegex("name"),
+			Pattern: strings.TrimSuffix(rotateRolePath, "/") + genericNameWithForwardSlashRegex("name"),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixLDAP,
 				OperationVerb:   "rotate",

--- a/path_rotate_test.go
+++ b/path_rotate_test.go
@@ -95,7 +95,7 @@ func TestManualRotateRole(t *testing.T) {
 		configureOpenLDAPMount(t, b, storage)
 		createRole(t, b, storage, roleName)
 
-		resp, _ := readStaticCred(t, b, storage, roleName)
+		resp := readStaticCred(t, b, storage, roleName)
 
 		if resp.Data["password"] == "" {
 			t.Fatal("expected password to be set, it wasn't")
@@ -114,7 +114,7 @@ func TestManualRotateRole(t *testing.T) {
 			t.Fatalf("err:%s resp:%#v\n", err, resp)
 		}
 
-		resp, _ = readStaticCred(t, b, storage, roleName)
+		resp = readStaticCred(t, b, storage, roleName)
 
 		if resp.Data["password"] == "" {
 			t.Fatal("expected password to be set after rotate, it wasn't")
@@ -142,7 +142,7 @@ func TestManualRotateRole(t *testing.T) {
 		passwords := make([]string, 0)
 		// rotate all the creds
 		for _, role := range roles {
-			resp, _ := readStaticCred(t, b, storage, role)
+			resp := readStaticCred(t, b, storage, role)
 
 			if resp.Data["password"] == "" {
 				t.Fatal("expected password to be set, it wasn't")
@@ -161,7 +161,7 @@ func TestManualRotateRole(t *testing.T) {
 				t.Fatalf("err:%s resp:%#v\n", err, resp)
 			}
 
-			resp, _ = readStaticCred(t, b, storage, role)
+			resp = readStaticCred(t, b, storage, role)
 
 			newPassword := resp.Data["password"]
 			if newPassword == "" {

--- a/path_rotate_test.go
+++ b/path_rotate_test.go
@@ -10,14 +10,15 @@ import (
 	"time"
 
 	"github.com/go-ldap/ldif"
+	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/hashicorp/vault-plugin-secrets-openldap/client"
 	"github.com/hashicorp/vault/sdk/helper/ldaputil"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestManualRotate(t *testing.T) {
-	t.Run("rotate root", func(t *testing.T) {
+func TestManualRotateRoot(t *testing.T) {
+	t.Run("happy path rotate root", func(t *testing.T) {
 		b, storage := getBackend(false)
 		defer b.Cleanup(context.Background())
 
@@ -83,23 +84,29 @@ func TestManualRotate(t *testing.T) {
 			t.Fatal("should have got error, didn't")
 		}
 	})
+}
 
-	t.Run("rotate role", func(t *testing.T) {
+func TestManualRotateRole(t *testing.T) {
+	t.Run("happy path rotate role", func(t *testing.T) {
 		b, storage := getBackend(false)
 		defer b.Cleanup(context.Background())
 
-		data := map[string]interface{}{
-			"binddn":      "tester",
-			"bindpass":    "pa$$w0rd",
-			"url":         "ldap://138.91.247.105",
-			"certificate": validCertificate,
+		roleName := "hashicorp"
+		configureOpenLDAPMount(t, b, storage)
+		createRole(t, b, storage, roleName)
+
+		resp, _ := readStaticCred(t, b, storage, roleName)
+
+		if resp.Data["password"] == "" {
+			t.Fatal("expected password to be set, it wasn't")
 		}
+		oldPassword := resp.Data["password"]
 
 		req := &logical.Request{
-			Operation: logical.CreateOperation,
-			Path:      configPath,
+			Operation: logical.UpdateOperation,
+			Path:      rotateRolePath + roleName,
 			Storage:   storage,
-			Data:      data,
+			Data:      nil,
 		}
 
 		resp, err := b.HandleRequest(context.Background(), req)
@@ -107,76 +114,7 @@ func TestManualRotate(t *testing.T) {
 			t.Fatalf("err:%s resp:%#v\n", err, resp)
 		}
 
-		req = &logical.Request{
-			Operation: logical.UpdateOperation,
-			Path:      rotateRootPath,
-			Storage:   storage,
-			Data:      nil,
-		}
-
-		resp, err = b.HandleRequest(context.Background(), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
-
-		data = map[string]interface{}{
-			"username":        "hashicorp",
-			"dn":              "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
-			"rotation_period": "60s",
-		}
-
-		req = &logical.Request{
-			Operation: logical.CreateOperation,
-			Path:      staticRolePath + "hashicorp",
-			Storage:   storage,
-			Data:      data,
-		}
-
-		resp, err = b.HandleRequest(context.Background(), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
-
-		req = &logical.Request{
-			Operation: logical.ReadOperation,
-			Path:      staticCredPath + "hashicorp",
-			Storage:   storage,
-			Data:      nil,
-		}
-
-		resp, err = b.HandleRequest(context.Background(), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
-
-		if resp.Data["password"] == "" {
-			t.Fatal("expected password to be set, it wasn't")
-		}
-		oldPassword := resp.Data["password"]
-
-		req = &logical.Request{
-			Operation: logical.UpdateOperation,
-			Path:      rotateRolePath + "hashicorp",
-			Storage:   storage,
-			Data:      nil,
-		}
-
-		resp, err = b.HandleRequest(context.Background(), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
-
-		req = &logical.Request{
-			Operation: logical.ReadOperation,
-			Path:      staticCredPath + "hashicorp",
-			Storage:   storage,
-			Data:      nil,
-		}
-
-		resp, err = b.HandleRequest(context.Background(), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
+		resp, _ = readStaticCred(t, b, storage, roleName)
 
 		if resp.Data["password"] == "" {
 			t.Fatal("expected password to be set after rotate, it wasn't")
@@ -184,6 +122,61 @@ func TestManualRotate(t *testing.T) {
 
 		if oldPassword == resp.Data["password"] {
 			t.Fatal("expected passwords to be different after rotation, they weren't")
+		}
+	})
+
+	t.Run("happy path rotate role with hierarchical path", func(t *testing.T) {
+		b, storage := getBackend(false)
+		defer b.Cleanup(context.Background())
+
+		configureOpenLDAPMount(t, b, storage)
+
+		roles := []string{"org/secure", "org/platform/dev", "org/platform/support"}
+
+		// create all the roles
+		for _, role := range roles {
+			data := getTestStaticRoleConfig(role)
+			createStaticRoleWithData(t, b, storage, role, data)
+		}
+
+		passwords := make([]string, 0)
+		// rotate all the creds
+		for _, role := range roles {
+			resp, _ := readStaticCred(t, b, storage, role)
+
+			if resp.Data["password"] == "" {
+				t.Fatal("expected password to be set, it wasn't")
+			}
+			oldPassword := resp.Data["password"]
+
+			req := &logical.Request{
+				Operation: logical.UpdateOperation,
+				Path:      rotateRolePath + role,
+				Storage:   storage,
+				Data:      nil,
+			}
+
+			resp, err := b.HandleRequest(context.Background(), req)
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("err:%s resp:%#v\n", err, resp)
+			}
+
+			resp, _ = readStaticCred(t, b, storage, role)
+
+			newPassword := resp.Data["password"]
+			if newPassword == "" {
+				t.Fatal("expected password to be set after rotate, it wasn't")
+			}
+
+			if oldPassword == newPassword {
+				t.Fatal("expected passwords to be different after rotation, they weren't")
+			}
+			passwords = append(passwords, newPassword.(string))
+		}
+
+		// extra pendantic check that the hierarchical paths don't return the same data
+		if len(passwords) != len(strutil.RemoveDuplicates(passwords, false)) {
+			t.Fatal("expected unique static-role paths to return unique passwords")
 		}
 	})
 
@@ -284,7 +277,6 @@ func TestRollbackPassword(t *testing.T) {
 			}
 			assert.Equal(t, testCase.expectedPassword, fclient.password)
 			assert.Equal(t, testCase.expectedRollbackCalls, fclient.count)
-
 		})
 	}
 }

--- a/path_static_creds.go
+++ b/path_static_creds.go
@@ -16,7 +16,7 @@ const staticCredPath = "static-cred/"
 func (b *backend) pathStaticCredsCreate() []*framework.Path {
 	return []*framework.Path{
 		{
-			Pattern: strings.TrimSuffix(staticCredPath, "/") + GenericNameWithForwardSlashRegex("name"),
+			Pattern: strings.TrimSuffix(staticCredPath, "/") + genericNameWithForwardSlashRegex("name"),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixLDAP,
 				OperationVerb:   "request",

--- a/path_static_creds.go
+++ b/path_static_creds.go
@@ -5,6 +5,7 @@ package openldap
 
 import (
 	"context"
+	"strings"
 
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -15,7 +16,7 @@ const staticCredPath = "static-cred/"
 func (b *backend) pathStaticCredsCreate() []*framework.Path {
 	return []*framework.Path{
 		{
-			Pattern: staticCredPath + framework.GenericNameRegex("name"),
+			Pattern: strings.TrimSuffix(staticCredPath, "/") + GenericNameWithForwardSlashRegex("name"),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixLDAP,
 				OperationVerb:   "request",

--- a/path_static_creds_test.go
+++ b/path_static_creds_test.go
@@ -84,7 +84,7 @@ func assertReadStaticCred(t *testing.T, b *backend, storage logical.Storage, rol
 	t.Helper()
 	resp := readStaticCred(t, b, storage, roleName)
 
-	if resp.Data["dn"] != data["dn"] {
+	if resp.Data["dn"] != data["dn"] && data["dn"] != nil {
 		t.Fatalf("expected dn to be %s but got %s", data["dn"], resp.Data["dn"])
 	}
 
@@ -92,7 +92,7 @@ func assertReadStaticCred(t *testing.T, b *backend, storage logical.Storage, rol
 		t.Fatal("expected password to be set, it wasn't")
 	}
 
-	if resp.Data["username"] != data["username"] {
+	if resp.Data["username"] != data["username"] && data["username"] != nil {
 		t.Fatalf("expected username to be %s but got %s", data["username"], resp.Data["username"])
 	}
 

--- a/path_static_creds_test.go
+++ b/path_static_creds_test.go
@@ -14,90 +14,39 @@ func TestCreds(t *testing.T) {
 	t.Run("happy path with creds", func(t *testing.T) {
 		b, storage := getBackend(false)
 		defer b.Cleanup(context.Background())
+		configureOpenLDAPMount(t, b, storage)
 
 		data := map[string]interface{}{
-			"binddn":      "tester",
-			"bindpass":    "pa$$w0rd",
-			"url":         "ldap://138.91.247.105",
-			"certificate": validCertificate,
-		}
-
-		req := &logical.Request{
-			Operation: logical.CreateOperation,
-			Path:      configPath,
-			Storage:   storage,
-			Data:      data,
-		}
-
-		resp, err := b.HandleRequest(context.Background(), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
-
-		data = map[string]interface{}{
 			"username":        "hashicorp",
 			"dn":              "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
-			"rotation_period": "60s",
+			"rotation_period": float64(60),
 		}
 
-		req = &logical.Request{
-			Operation: logical.CreateOperation,
-			Path:      staticRolePath + "hashicorp",
-			Storage:   storage,
-			Data:      data,
+		roleName := "hashicorp"
+		createStaticRoleWithData(t, b, storage, roleName, data)
+		assertReadStaticCred(t, b, storage, roleName, data)
+	})
+
+	t.Run("happy path with hierarchical cred path", func(t *testing.T) {
+		b, storage := getBackend(false)
+		defer b.Cleanup(context.Background())
+		configureOpenLDAPMount(t, b, storage)
+
+		roles := []string{"org/secure", "org/platform/dev", "org/platform/support"}
+
+		// create all the roles
+		for _, role := range roles {
+			data := getTestStaticRoleConfig(role)
+			resp, err := createStaticRoleWithData(t, b, storage, role, data)
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("err:%s resp:%#v\n", err, resp)
+			}
 		}
 
-		resp, err = b.HandleRequest(context.Background(), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
-
-		req = &logical.Request{
-			Operation: logical.ReadOperation,
-			Path:      staticRolePath + "hashicorp",
-			Storage:   storage,
-			Data:      nil,
-		}
-
-		resp, err = b.HandleRequest(context.Background(), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
-
-		req = &logical.Request{
-			Operation: logical.ReadOperation,
-			Path:      staticCredPath + "hashicorp",
-			Storage:   storage,
-			Data:      nil,
-		}
-
-		resp, err = b.HandleRequest(context.Background(), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
-
-		if resp.Data["dn"] == "" {
-			t.Fatal("expected dn to be set, it wasn't")
-		}
-
-		if resp.Data["password"] == "" {
-			t.Fatal("expected password to be set, it wasn't")
-		}
-
-		if resp.Data["username"] == "" {
-			t.Fatal("expected username to be set, it wasn't")
-		}
-
-		if resp.Data["last_vault_rotation"] == nil {
-			t.Fatal("expected last_vault_rotation to be set, it wasn't")
-		}
-
-		if resp.Data["rotation_period"] != float64(60) {
-			t.Fatalf("expected rotation_period to be %f, got %f", float64(60), resp.Data["rotation_period"])
-		}
-
-		if resp.Data["ttl"] == nil {
-			t.Fatal("expected ttl to be set, it wasn't")
+		// read all the creds
+		for _, role := range roles {
+			data := getTestStaticRoleConfig(role)
+			assertReadStaticCred(t, b, storage, role, data)
 		}
 	})
 
@@ -105,14 +54,7 @@ func TestCreds(t *testing.T) {
 		b, storage := getBackend(false)
 		defer b.Cleanup(context.Background())
 
-		req := &logical.Request{
-			Operation: logical.ReadOperation,
-			Path:      staticCredPath + "hashicorp",
-			Storage:   storage,
-			Data:      nil,
-		}
-
-		resp, err := b.HandleRequest(context.Background(), req)
+		resp, err := readStaticCred(t, b, storage, "hashicorp")
 		if err != nil {
 			t.Fatalf("error reading cred: %s", err)
 		}
@@ -120,4 +62,48 @@ func TestCreds(t *testing.T) {
 			t.Fatal("expected error")
 		}
 	})
+}
+
+func readStaticCred(t *testing.T, b *backend, storage logical.Storage, roleName string) (*logical.Response, error) {
+	req := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      staticCredPath + roleName,
+		Storage:   storage,
+		Data:      nil,
+	}
+
+	return b.HandleRequest(context.Background(), req)
+}
+
+func assertReadStaticCred(t *testing.T, b *backend, storage logical.Storage, roleName string, data map[string]interface{}) {
+	t.Helper()
+	resp, err := readStaticCred(t, b, storage, roleName)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+	if resp.Data["dn"] != data["dn"] {
+		t.Fatalf("expected dn to be %s but got %s", data["dn"], resp.Data["dn"])
+	}
+
+	if resp.Data["password"] == "" {
+		t.Fatal("expected password to be set, it wasn't")
+	}
+
+	if resp.Data["username"] != data["username"] {
+		t.Fatalf("expected username to be %s but got %s", data["username"], resp.Data["username"])
+	}
+
+	if resp.Data["last_vault_rotation"] == nil {
+		t.Fatal("expected last_vault_rotation to be set, it wasn't")
+	}
+
+	expected := data["rotation_period"].(float64)
+	if resp.Data["rotation_period"] != expected {
+		t.Fatalf("expected rotation_period to be %f but got %s", expected, resp.Data["rotation_period"])
+	}
+
+	if resp.Data["ttl"] == nil {
+		t.Fatal("expected ttl to be set, it wasn't")
+	}
 }

--- a/path_static_roles.go
+++ b/path_static_roles.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -20,10 +21,23 @@ const (
 	staticRolePath = "static-role/"
 )
 
+// RolePathRegex is a regex which requires a role name. The role name
+// can include any number of characters separated by forward slashes.
+func RolePathRegex(name string) string {
+	return fmt.Sprintf("(/(?P<%s>.+))", name)
+}
+
+// RoleListRegex is a regex for optionally including a role path in
+// list options. The role path can be used to list nested roles at
+// arbitrary depth.
+func RoleListRegex(name string) string {
+	return fmt.Sprintf("/?(/(?P<%s>.+/))?", name)
+}
+
 func (b *backend) pathListStaticRoles() []*framework.Path {
 	return []*framework.Path{
 		{
-			Pattern: staticRolePath + "?$",
+			Pattern: strings.TrimSuffix(staticRolePath, "/") + RoleListRegex("path"),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixLDAP,
 				OperationVerb:   "list",
@@ -32,6 +46,12 @@ func (b *backend) pathListStaticRoles() []*framework.Path {
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ListOperation: &framework.PathOperation{
 					Callback: b.pathStaticRoleList,
+				},
+			},
+			Fields: map[string]*framework.FieldSchema{
+				"path": {
+					Type:        framework.TypeLowerCaseString,
+					Description: "Path of roles to list",
 				},
 			},
 			HelpSynopsis:    staticRolesListHelpSynopsis,
@@ -43,7 +63,7 @@ func (b *backend) pathListStaticRoles() []*framework.Path {
 func (b *backend) pathStaticRoles() []*framework.Path {
 	return []*framework.Path{
 		{
-			Pattern: staticRolePath + framework.GenericNameRegex("name"),
+			Pattern: strings.TrimSuffix(staticRolePath, "/") + RolePathRegex("name"),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixLDAP,
 				OperationSuffix: "static-role",
@@ -438,7 +458,8 @@ func (s *staticAccount) PasswordTTL() time.Duration {
 }
 
 func (b *backend) pathStaticRoleList(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	roles, err := req.Storage.List(ctx, staticRolePath)
+	rolePath := data.Get("path").(string)
+	roles, err := req.Storage.List(ctx, staticRolePath+rolePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list roles: %w", err)
 	}

--- a/path_static_roles.go
+++ b/path_static_roles.go
@@ -31,6 +31,7 @@ func GenericNameWithForwardSlashRegex(name string) string {
 // role path in list options. The role path can be used to list nested roles at
 // arbitrary depth.
 func OptionalGenericNameWithForwardSlashListRegex(name string) string {
+	// TODO(JM): List regex should support optional trailing slash
 	return fmt.Sprintf("/?(/(?P<%s>.+/))?", name)
 }
 

--- a/path_static_roles.go
+++ b/path_static_roles.go
@@ -21,16 +21,16 @@ const (
 	staticRolePath = "static-role/"
 )
 
-// GenericNameWithForwardSlashRegex is a regex which requires a role name. The role name can
-// include any number of alphanumberic characters separated by forward slashes.
-func GenericNameWithForwardSlashRegex(name string) string {
-	return fmt.Sprintf("(/(?P<%s>\\w(([\\w-./]+)?\\w)?))", name)
+// genericNameWithForwardSlashRegex is a regex which requires a role name. The role name can
+// include any number of alphanumeric characters separated by forward slashes.
+func genericNameWithForwardSlashRegex(name string) string {
+	return fmt.Sprintf(`(/(?P<%s>\w(([\w-./]+)?\w)?))`, name)
 }
 
-// OptionalGenericNameWithForwardSlashListRegex is a regex for optionally including a
+// optionalGenericNameWithForwardSlashListRegex is a regex for optionally including a
 // role path in list options. The role path can be used to list nested roles at
 // arbitrary depth.
-func OptionalGenericNameWithForwardSlashListRegex(name string) string {
+func optionalGenericNameWithForwardSlashListRegex(name string) string {
 	// TODO(JM): List regex should support optional trailing slash
 	return fmt.Sprintf("/?(/(?P<%s>.+/))?", name)
 }
@@ -38,7 +38,7 @@ func OptionalGenericNameWithForwardSlashListRegex(name string) string {
 func (b *backend) pathListStaticRoles() []*framework.Path {
 	return []*framework.Path{
 		{
-			Pattern: strings.TrimSuffix(staticRolePath, "/") + OptionalGenericNameWithForwardSlashListRegex("path"),
+			Pattern: strings.TrimSuffix(staticRolePath, "/") + optionalGenericNameWithForwardSlashListRegex("path"),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixLDAP,
 				OperationVerb:   "list",
@@ -64,7 +64,7 @@ func (b *backend) pathListStaticRoles() []*framework.Path {
 func (b *backend) pathStaticRoles() []*framework.Path {
 	return []*framework.Path{
 		{
-			Pattern: strings.TrimSuffix(staticRolePath, "/") + GenericNameWithForwardSlashRegex("name"),
+			Pattern: strings.TrimSuffix(staticRolePath, "/") + genericNameWithForwardSlashRegex("name"),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixLDAP,
 				OperationSuffix: "static-role",

--- a/path_static_roles.go
+++ b/path_static_roles.go
@@ -21,23 +21,23 @@ const (
 	staticRolePath = "static-role/"
 )
 
-// RolePathRegex is a regex which requires a role name. The role name
-// can include any number of characters separated by forward slashes.
-func RolePathRegex(name string) string {
-	return fmt.Sprintf("(/(?P<%s>.+))", name)
+// GenericNameWithForwardSlashRegex is a regex which requires a role name. The role name can
+// include any number of alphanumberic characters separated by forward slashes.
+func GenericNameWithForwardSlashRegex(name string) string {
+	return fmt.Sprintf("(/(?P<%s>\\w(([\\w-./]+)?\\w)?))", name)
 }
 
-// RoleListRegex is a regex for optionally including a role path in
-// list options. The role path can be used to list nested roles at
+// OptionalGenericNameWithForwardSlashListRegex is a regex for optionally including a
+// role path in list options. The role path can be used to list nested roles at
 // arbitrary depth.
-func RoleListRegex(name string) string {
+func OptionalGenericNameWithForwardSlashListRegex(name string) string {
 	return fmt.Sprintf("/?(/(?P<%s>.+/))?", name)
 }
 
 func (b *backend) pathListStaticRoles() []*framework.Path {
 	return []*framework.Path{
 		{
-			Pattern: strings.TrimSuffix(staticRolePath, "/") + RoleListRegex("path"),
+			Pattern: strings.TrimSuffix(staticRolePath, "/") + OptionalGenericNameWithForwardSlashListRegex("path"),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixLDAP,
 				OperationVerb:   "list",
@@ -63,7 +63,7 @@ func (b *backend) pathListStaticRoles() []*framework.Path {
 func (b *backend) pathStaticRoles() []*framework.Path {
 	return []*framework.Path{
 		{
-			Pattern: strings.TrimSuffix(staticRolePath, "/") + RolePathRegex("name"),
+			Pattern: strings.TrimSuffix(staticRolePath, "/") + GenericNameWithForwardSlashRegex("name"),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: operationPrefixLDAP,
 				OperationSuffix: "static-role",

--- a/path_static_roles_test.go
+++ b/path_static_roles_test.go
@@ -504,7 +504,7 @@ func TestListRoles(t *testing.T) {
 		for _, rolePath := range rolePaths {
 			req := &logical.Request{
 				Operation: logical.ListOperation,
-				Path:      staticRolePath + "/" + rolePath,
+				Path:      staticRolePath + rolePath,
 				Storage:   storage,
 				Data:      nil,
 			}
@@ -515,7 +515,6 @@ func TestListRoles(t *testing.T) {
 			}
 
 			keys := resp.Data["keys"].([]string)
-			t.Logf("keys: %#+v", keys)
 			if len(keys) != 2 {
 				t.Fatalf("expected list with %d keys, got %d", 2, len(keys))
 			}

--- a/path_static_roles_test.go
+++ b/path_static_roles_test.go
@@ -214,29 +214,6 @@ func Test_backend_pathStaticRoleLifecycle(t *testing.T) {
 }
 
 func TestRoles(t *testing.T) {
-	t.Run("happy path with hierarchical role path", func(t *testing.T) {
-		b, storage := getBackend(false)
-		defer b.Cleanup(context.Background())
-
-		configureOpenLDAPMount(t, b, storage)
-
-		roles := []string{"org/secure", "org/platform/dev", "org/platform/support"}
-
-		// create all the roles
-		for _, role := range roles {
-			data := getTestStaticRoleConfig(role)
-			resp, err := createStaticRoleWithData(t, b, storage, role, data)
-			if err != nil || (resp != nil && resp.IsError()) {
-				t.Fatalf("err:%s resp:%#v\n", err, resp)
-			}
-		}
-
-		// read all the roles
-		for _, role := range roles {
-			data := getTestStaticRoleConfig(role)
-			assertReadStaticRole(t, b, storage, role, data)
-		}
-	})
 	t.Run("happy path with role using DN search", func(t *testing.T) {
 		b, storage := getBackend(false)
 		defer b.Cleanup(context.Background())
@@ -430,6 +407,30 @@ func TestRoles(t *testing.T) {
 		}
 		if resp != nil {
 			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("happy path with hierarchical role path", func(t *testing.T) {
+		b, storage := getBackend(false)
+		defer b.Cleanup(context.Background())
+
+		configureOpenLDAPMount(t, b, storage)
+
+		roles := []string{"org/secure", "org/platform/dev", "org/platform/support"}
+
+		// create all the roles
+		for _, role := range roles {
+			data := getTestStaticRoleConfig(role)
+			resp, err := createStaticRoleWithData(t, b, storage, role, data)
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("err:%s resp:%#v\n", err, resp)
+			}
+		}
+
+		// read all the roles
+		for _, role := range roles {
+			data := getTestStaticRoleConfig(role)
+			assertReadStaticRole(t, b, storage, role, data)
 		}
 	})
 }

--- a/path_static_roles_test.go
+++ b/path_static_roles_test.go
@@ -221,17 +221,10 @@ func TestRoles(t *testing.T) {
 		configureOpenLDAPMount(t, b, storage)
 
 		roles := []string{"org/secure", "org/platform/dev", "org/platform/support"}
-		getData := func(name string) map[string]interface{} {
-			return map[string]interface{}{
-				"username":        name,
-				"dn":              "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
-				"rotation_period": float64(5),
-			}
-		}
 
 		// create all the roles
 		for _, role := range roles {
-			data := getData(role)
+			data := getTestStaticRoleConfig(role)
 			resp, err := createStaticRoleWithData(t, b, storage, role, data)
 			if err != nil || (resp != nil && resp.IsError()) {
 				t.Fatalf("err:%s resp:%#v\n", err, resp)
@@ -240,7 +233,7 @@ func TestRoles(t *testing.T) {
 
 		// read all the roles
 		for _, role := range roles {
-			data := getData(role)
+			data := getTestStaticRoleConfig(role)
 			assertReadStaticRole(t, b, storage, role, data)
 		}
 	})
@@ -494,17 +487,10 @@ func TestListRoles(t *testing.T) {
 		configureOpenLDAPMount(t, b, storage)
 
 		roles := []string{"org/secure", "org/platform/dev", "org/platform/support"}
-		getData := func(name string) map[string]interface{} {
-			return map[string]interface{}{
-				"username":        name,
-				"dn":              "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
-				"rotation_period": float64(5),
-			}
-		}
 
 		// create all the roles
 		for _, role := range roles {
-			data := getData(role)
+			data := getTestStaticRoleConfig(role)
 			resp, err := createStaticRoleWithData(t, b, storage, role, data)
 			if err != nil || (resp != nil && resp.IsError()) {
 				t.Fatalf("err:%s resp:%#v\n", err, resp)
@@ -734,5 +720,13 @@ func assertReadStaticRole(t *testing.T, b *backend, storage logical.Storage, rol
 
 	if resp.Data["last_vault_rotation"] == nil {
 		t.Fatal("expected last_vault_rotation to not be empty")
+	}
+}
+
+func getTestStaticRoleConfig(name string) map[string]interface{} {
+	return map[string]interface{}{
+		"username":        name,
+		"dn":              "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
+		"rotation_period": float64(5),
 	}
 }


### PR DESCRIPTION
Phase 2 of https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/102 and is based on that branch.

This PR adds hierarchical path handling to the following APIs:
- [Dynamic roles](https://developer.hashicorp.com/vault/api-docs/secret/ldap#dynamic-roles)
- [Dynamic role passwords](https://developer.hashicorp.com/vault/api-docs/secret/ldap#dynamic-role-passwords)

