### PR TITLE
properly handle init queue for hierarchical paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+## v0.14.1
+
+BUG FIXES:
+* fix a panic on init when static roles have names defined as hierarchical paths (https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/115)
+
 ## v0.14.0
 
 ### IMPROVEMENTS:


### PR DESCRIPTION
This PR fixes a bug where roles names with hierarchical paths caused a panic on reloads of the backend.

Roles can be defined with hierarchical paths, e.g. "foo/bar/baz". Howerver, the storage.List() call to the top-level static role path will only return the top-level keys in the hierarchy. So we perform a non-recursive breadth-first search through all the keys returned from storage.List(). If a given node points to a static role, we append to the return slice and use that slice to initialize the queue.


Closes https://github.com/hashicorp/vault/issues/27907