### PR TITLE
Backport to v0.13.x: properly handle init queue for hierarchical paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+## v0.13.1
+
+BUG FIXES:
+* fix a panic on init when static roles have names defined as hierarchical paths (https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/115)
+
 ## v0.13.0
 
 FEATURES:


### PR DESCRIPTION

Backport of https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/115