### PR TITLE
VAULT-9208: updating rotate role to handle case sensitivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 ## Unreleased
 
+## v0.14.2
+
 BUG FIXES:
 
 * fix a panic on static role creation when the config is unset (https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/119)
+
+* fix case sensitivity issues in the role rotation process (https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/118)
 
 ## v0.14.1
 

--- a/path_rotate.go
+++ b/path_rotate.go
@@ -124,7 +124,7 @@ due to %s, configure a new binddn and bindpass to restore ldap function`, pwdSto
 }
 
 func (b *backend) pathRotateRoleCredentialsUpdate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	name := data.Get("name").(string)
+	name := strings.ToLower(data.Get("name").(string)) // Convert to lowercase
 	if name == "" {
 		return logical.ErrorResponse("empty role name attribute given"), nil
 	}

--- a/path_rotate.go
+++ b/path_rotate.go
@@ -55,12 +55,7 @@ func (b *backend) pathRotateCredentials() []*framework.Path {
 				OperationVerb:   "rotate",
 				OperationSuffix: "static-role",
 			},
-			Fields: map[string]*framework.FieldSchema{
-				"name": {
-					Type:        framework.TypeString,
-					Description: "Name of the static role",
-				},
-			},
+			Fields: fieldsForType(rotateRolePath),
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.UpdateOperation: &framework.PathOperation{
 					Callback:                    b.pathRotateRoleCredentialsUpdate,
@@ -124,7 +119,7 @@ due to %s, configure a new binddn and bindpass to restore ldap function`, pwdSto
 }
 
 func (b *backend) pathRotateRoleCredentialsUpdate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	name := strings.ToLower(data.Get("name").(string)) // Convert to lowercase
+	name := data.Get("name").(string)
 	if name == "" {
 		return logical.ErrorResponse("empty role name attribute given"), nil
 	}

--- a/path_static_roles.go
+++ b/path_static_roles.go
@@ -471,7 +471,7 @@ func (b *backend) pathStaticRoleList(ctx context.Context, req *logical.Request, 
 }
 
 func (b *backend) staticRole(ctx context.Context, s logical.Storage, roleName string) (*roleEntry, error) {
-	completeRole := strings.ToLower(staticRolePath + roleName)
+	completeRole := staticRolePath + roleName
 	entry, err := s.Get(ctx, completeRole)
 	if err != nil {
 		return nil, err

--- a/path_static_roles.go
+++ b/path_static_roles.go
@@ -471,7 +471,8 @@ func (b *backend) pathStaticRoleList(ctx context.Context, req *logical.Request, 
 }
 
 func (b *backend) staticRole(ctx context.Context, s logical.Storage, roleName string) (*roleEntry, error) {
-	entry, err := s.Get(ctx, staticRolePath+roleName)
+	completeRole := strings.ToLower(staticRolePath + roleName)
+	entry, err := s.Get(ctx, completeRole)
 	if err != nil {
 		return nil, err
 	}

--- a/rotation_test.go
+++ b/rotation_test.go
@@ -5,6 +5,7 @@ package openldap
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -203,104 +204,132 @@ func TestAutoRotate(t *testing.T) {
 // a password policy change should cause the WAL to be discarded and a new
 // password to be generated using the updated policy.
 func TestPasswordPolicyModificationInvalidatesWAL(t *testing.T) {
-	ctx := context.Background()
-	b, storage := getBackend(false)
-	defer b.Cleanup(ctx)
+	for _, tc := range []struct {
+		testName string
+	}{
+		{
+			"hashicorp",
+		},
+		{
+			"HASHICORP",
+		},
+		{
+			"hashicORp",
+		},
+	} {
+		ctx := context.Background()
+		b, storage := getBackend(false)
+		defer b.Cleanup(ctx)
 
-	configureOpenLDAPMountWithPasswordPolicy(t, b, storage, testPasswordPolicy1)
-	createRole(t, b, storage, "hashicorp")
+		configureOpenLDAPMountWithPasswordPolicy(t, b, storage, testPasswordPolicy1)
+		createRole(t, b, storage, "hashicorp")
 
-	// Create a WAL entry from a partial failure to rotate
-	generateWALFromFailedRotation(t, b, storage, "hashicorp")
-	requireWALs(t, storage, 1)
+		// Create a WAL entry from a partial failure to rotate
+		generateWALFromFailedRotation(t, b, storage, "hashicorp")
+		requireWALs(t, storage, 1)
 
-	// The role password should still be the password generated from policy 1
-	role, err := b.staticRole(ctx, storage, "hashicorp")
-	if err != nil {
-		t.Fatal(err)
+		// The role password should still be the password generated from policy 1
+		role, err := b.staticRole(ctx, storage, tc.testName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if role.StaticAccount.Password != testPasswordFromPolicy1 {
+			t.Fatalf("expected %v, got %v", testPasswordFromPolicy1, role.StaticAccount.Password)
+		}
+
+		// Update the password policy on the configuration
+		configureOpenLDAPMountWithPasswordPolicy(t, b, storage, testPasswordPolicy2)
+
+		// Manually rotate the role. It should not use the password from the WAL entry
+		// created earlier. Instead, it should result in generation of a new password
+		// using the updated policy 2.
+		_, err = b.HandleRequest(ctx, &logical.Request{
+			Operation: logical.UpdateOperation,
+			Path:      "rotate-role/hashicorp",
+			Storage:   storage,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// The role password should be the password generated from policy 2
+		role, err = b.staticRole(ctx, storage, tc.testName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if role.StaticAccount.Password != testPasswordFromPolicy2 {
+			t.Fatalf("expected %v, got %v", testPasswordFromPolicy2, role.StaticAccount.Password)
+		}
+		if role.StaticAccount.LastPassword != testPasswordFromPolicy1 {
+			t.Fatalf("expected %v, got %v", testPasswordFromPolicy1, role.StaticAccount.LastPassword)
+		}
+
+		// The WAL entry should be deleted after the successful rotation
+		requireWALs(t, storage, 0)
 	}
-	if role.StaticAccount.Password != testPasswordFromPolicy1 {
-		t.Fatalf("expected %v, got %v", testPasswordFromPolicy1, role.StaticAccount.Password)
-	}
-
-	// Update the password policy on the configuration
-	configureOpenLDAPMountWithPasswordPolicy(t, b, storage, testPasswordPolicy2)
-
-	// Manually rotate the role. It should not use the password from the WAL entry
-	// created earlier. Instead, it should result in generation of a new password
-	// using the updated policy 2.
-	_, err = b.HandleRequest(ctx, &logical.Request{
-		Operation: logical.UpdateOperation,
-		Path:      "rotate-role/hashicorp",
-		Storage:   storage,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// The role password should be the password generated from policy 2
-	role, err = b.staticRole(ctx, storage, "hashicorp")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if role.StaticAccount.Password != testPasswordFromPolicy2 {
-		t.Fatalf("expected %v, got %v", testPasswordFromPolicy2, role.StaticAccount.Password)
-	}
-	if role.StaticAccount.LastPassword != testPasswordFromPolicy1 {
-		t.Fatalf("expected %v, got %v", testPasswordFromPolicy1, role.StaticAccount.LastPassword)
-	}
-
-	// The WAL entry should be deleted after the successful rotation
-	requireWALs(t, storage, 0)
 }
 
 func TestRollsPasswordForwardsUsingWAL(t *testing.T) {
-	ctx := context.Background()
-	b, storage := getBackend(false)
-	defer b.Cleanup(ctx)
-	configureOpenLDAPMount(t, b, storage)
-	createRole(t, b, storage, "hashicorp")
+	for _, tc := range []struct {
+		testName string
+	}{
+		{
+			"hashicorp",
+		},
+		{
+			"HASHICORP",
+		},
+		{
+			"hashicORp",
+		},
+	} {
+		ctx := context.Background()
+		b, storage := getBackend(false)
+		defer b.Cleanup(ctx)
+		configureOpenLDAPMount(t, b, storage)
+		createRole(t, b, storage, "hashicorp")
 
-	role, err := b.staticRole(ctx, storage, "hashicorp")
-	if err != nil {
-		t.Fatal(err)
-	}
-	oldPassword := role.StaticAccount.Password
+		role, err := b.staticRole(ctx, storage, tc.testName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		oldPassword := role.StaticAccount.Password
 
-	generateWALFromFailedRotation(t, b, storage, "hashicorp")
-	walIDs := requireWALs(t, storage, 1)
-	wal, err := b.findStaticWAL(ctx, storage, walIDs[0])
-	if err != nil {
-		t.Fatal(err)
-	}
-	role, err = b.staticRole(ctx, storage, "hashicorp")
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Role's password should still be the WAL's old password
-	if role.StaticAccount.Password != oldPassword {
-		t.Fatal(role.StaticAccount.Password, oldPassword)
-	}
+		generateWALFromFailedRotation(t, b, storage, tc.testName)
+		walIDs := requireWALs(t, storage, 1)
+		wal, err := b.findStaticWAL(ctx, storage, walIDs[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		role, err = b.staticRole(ctx, storage, tc.testName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Role's password should still be the WAL's old password
+		if role.StaticAccount.Password != oldPassword {
+			t.Fatal(role.StaticAccount.Password, oldPassword)
+		}
 
-	// Trigger a retry on the rotation, it should use WAL's new password
-	_, err = b.HandleRequest(ctx, &logical.Request{
-		Operation: logical.UpdateOperation,
-		Path:      "rotate-role/hashicorp",
-		Storage:   storage,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+		// Trigger a retry on the rotation, it should use WAL's new password
+		_, err = b.HandleRequest(ctx, &logical.Request{
+			Operation: logical.UpdateOperation,
+			Path:      fmt.Sprintf("rotate-role/%s", tc.testName),
+			Storage:   storage,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	role, err = b.staticRole(ctx, storage, "hashicorp")
-	if err != nil {
-		t.Fatal(err)
+		role, err = b.staticRole(ctx, storage, tc.testName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if role.StaticAccount.Password != wal.NewPassword {
+			t.Fatal(role.StaticAccount.Password, wal.NewPassword)
+		}
+		// WAL should be cleared by the successful rotate
+		requireWALs(t, storage, 0)
 	}
-	if role.StaticAccount.Password != wal.NewPassword {
-		t.Fatal(role.StaticAccount.Password, wal.NewPassword)
-	}
-	// WAL should be cleared by the successful rotate
-	requireWALs(t, storage, 0)
 }
 
 func TestStoredWALsCorrectlyProcessed(t *testing.T) {

--- a/rotation_test.go
+++ b/rotation_test.go
@@ -6,6 +6,7 @@ package openldap
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -229,7 +230,7 @@ func TestPasswordPolicyModificationInvalidatesWAL(t *testing.T) {
 		requireWALs(t, storage, 1)
 
 		// The role password should still be the password generated from policy 1
-		role, err := b.staticRole(ctx, storage, tc.testName)
+		role, err := b.staticRole(ctx, storage, strings.ToLower(tc.testName))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -253,7 +254,7 @@ func TestPasswordPolicyModificationInvalidatesWAL(t *testing.T) {
 		}
 
 		// The role password should be the password generated from policy 2
-		role, err = b.staticRole(ctx, storage, tc.testName)
+		role, err = b.staticRole(ctx, storage, strings.ToLower(tc.testName))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -289,7 +290,7 @@ func TestRollsPasswordForwardsUsingWAL(t *testing.T) {
 		configureOpenLDAPMount(t, b, storage)
 		createRole(t, b, storage, "hashicorp")
 
-		role, err := b.staticRole(ctx, storage, tc.testName)
+		role, err := b.staticRole(ctx, storage, strings.ToLower(tc.testName))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -301,7 +302,7 @@ func TestRollsPasswordForwardsUsingWAL(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		role, err = b.staticRole(ctx, storage, tc.testName)
+		role, err = b.staticRole(ctx, storage, strings.ToLower(tc.testName))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -320,7 +321,7 @@ func TestRollsPasswordForwardsUsingWAL(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		role, err = b.staticRole(ctx, storage, tc.testName)
+		role, err = b.staticRole(ctx, storage, strings.ToLower(tc.testName))
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
# Overview
This update improves OpenLDAP by allowing role rotation without case sensitivity concerns, enabling users to rotate roles using any letter case.

# Related Issues/Pull Requests
- ~~[ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)~~
- ~~[ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)~~

# Contributor Checklist
- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [ ] Backwards compatible
