### PR TITLE
prevent role and set duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## v0.14.3
+
+BUG FIXES:
+
+* fix an edge case where add an LDAP user or service account can be added to more than one role or set (https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/123)
+
 ## v0.14.2
 
 BUG FIXES:

--- a/backend.go
+++ b/backend.go
@@ -5,6 +5,7 @@ package openldap
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 
@@ -149,10 +150,57 @@ type backend struct {
 	checkOutLocks []*locksutil.LockEntry
 }
 
+// walkfunc type takes a storage path argument and returns true if a storage
+// entry exists, false otherwise
+type walkFunc func(string) (bool, error)
+
+// walkStoragePath performs a non-recursive breadth-first search of the given
+// storage path and applies the walkfunc to each storage entry
+func walkStoragePath(ctx context.Context, s logical.Storage, path string, walker walkFunc) error {
+	keys, err := s.List(ctx, path)
+	if err != nil {
+		return fmt.Errorf("unable to list keys: %w", err)
+	}
+
+	// Storage entries can be defined with hierarchical paths, e.g.
+	// "foo/bar/baz". But the storage.List() call to the top-level key will
+	// only return the top-level keys in the hierarchy. So we perform a
+	// non-recursive breadth-first search through all the keys returned from
+	// storage.List() and apply the walkfunc.
+	for i := 0; i < len(keys); i++ {
+		key := keys[i]
+
+		entryExists, err := walker(key)
+		if err != nil {
+			return fmt.Errorf("unable to read entry %q: %w", key, err)
+		}
+
+		if !entryExists && strings.HasSuffix(key, "/") {
+			// this is a directory
+			subKeys, err := s.List(ctx, path+key)
+			if err != nil {
+				return fmt.Errorf("unable to list keys: %w", err)
+			}
+
+			// append to the keys slice to continue search in the sub-directory
+			for _, subKey := range subKeys {
+				// prevent infinite loop but this should never happen
+				if subKey == "" {
+					continue
+				}
+				subKey = fmt.Sprintf("%s%s", key, subKey)
+				keys = append(keys, subKey)
+			}
+		}
+	}
+	return nil
+}
+
 // loadManagedUsers loads users managed by the secrets engine from storage into
 // the backend's managedUsers set. Users are loaded from both the static role and
 // check-in/check-out systems. Returns an error if one occurs during loading.
 func (b *backend) loadManagedUsers(ctx context.Context, s logical.Storage) error {
+	log := b.Logger()
 	b.managedUserLock.Lock()
 	defer b.managedUserLock.Unlock()
 
@@ -162,16 +210,26 @@ func (b *backend) loadManagedUsers(ctx context.Context, s logical.Storage) error
 	b.managedUsers = make(map[string]struct{})
 
 	// Load users managed under static roles
-	staticRoles, err := s.List(ctx, staticRolePath)
+	roles := map[string]*roleEntry{}
+	roleFunc := func(roleName string) (bool, error) {
+		entry, err := b.staticRole(ctx, s, roleName)
+		if err != nil {
+			log.Warn("unable to read static role", "error", err, "role", roleName)
+			return false, err
+		}
+		entryExists := entry != nil && !strings.HasSuffix(roleName, "/")
+		if entryExists {
+			roles[roleName] = entry
+		}
+		return entryExists, nil
+	}
+	err := walkStoragePath(ctx, s, staticRolePath, roleFunc)
 	if err != nil {
 		return err
 	}
-	for _, roleName := range staticRoles {
-		staticRole, err := b.staticRole(ctx, s, roleName)
-		if err != nil {
-			return err
-		}
-		if staticRole == nil || staticRole.StaticAccount == nil {
+
+	for roleName, role := range roles {
+		if role == nil || role.StaticAccount == nil {
 			// This indicates that a static role returned from the list operation was
 			// deleted before the read operation in this loop. This shouldn't happen
 			// at this point in the plugin lifecycle, so we'll log if it does.
@@ -181,19 +239,28 @@ func (b *backend) loadManagedUsers(ctx context.Context, s logical.Storage) error
 		}
 
 		// Add the static role user to the managed user set
-		b.managedUsers[staticRole.StaticAccount.Username] = struct{}{}
+		b.managedUsers[role.StaticAccount.Username] = struct{}{}
 	}
 
 	// Load users managed under library sets
-	librarySets, err := s.List(ctx, libraryPrefix)
+	librarySets := map[string]*librarySet{}
+	setFunc := func(setName string) (bool, error) {
+		entry, err := readSet(ctx, s, setName)
+		if err != nil {
+			log.Warn("unable to read library set", "error", err, "set", setName)
+			return false, err
+		}
+		entryExists := entry != nil && !strings.HasSuffix(setName, "/")
+		if entryExists {
+			librarySets[setName] = entry
+		}
+		return entryExists, nil
+	}
+	err = walkStoragePath(ctx, s, libraryPrefix, setFunc)
 	if err != nil {
 		return err
 	}
-	for _, setName := range librarySets {
-		set, err := readSet(ctx, s, setName)
-		if err != nil {
-			return err
-		}
+	for setName, set := range librarySets {
 		if set == nil {
 			// This indicates that a library set returned from the list operation was
 			// deleted before the read operation in this loop. This shouldn't happen

--- a/backend_test.go
+++ b/backend_test.go
@@ -57,7 +57,7 @@ func getBackend(throwsErr bool) (*backend, logical.Storage) {
 	// Load queue and kickoff new periodic ticker
 	b.initQueue(ictx, &logical.InitializationRequest{
 		Storage: config.StorageView,
-	})
+	}, nil)
 
 	return b, config.StorageView
 }

--- a/path_checkout_sets_test.go
+++ b/path_checkout_sets_test.go
@@ -129,6 +129,22 @@ func TestCheckOutHierarchicalPaths(t *testing.T) {
 		tSuiteForList = ts
 	}
 
+	// Reset the managed users to simulate startup memory state
+	b.managedUsers = make(map[string]struct{})
+	// Now finish the startup process by populating the managed users
+	b.loadManagedUsers(ctx, s)
+
+	for _, setName := range setNames {
+		ts := testSuite{
+			b:               b,
+			s:               s,
+			name:            setName,
+			svcAccountNames: getTestSvcAccountNames(setName, 2),
+		}
+
+		t.Run("write conflicting set", ts.WriteSetWithConflictingServiceAccounts())
+	}
+
 	tests := []struct {
 		path             string
 		expectedListResp []string
@@ -143,7 +159,7 @@ func TestCheckOutHierarchicalPaths(t *testing.T) {
 	}
 
 	// `LIST /library`
-	// will direct sub-keys split on "/" for the FIRST level (split) only
+	// will return direct sub-keys split on "/" for the FIRST level (split) only
 	t.Run("list library hierarchy", tSuiteForList.ListSets([]string{"foo", "org/"}))
 }
 

--- a/rotation_test.go
+++ b/rotation_test.go
@@ -82,10 +82,16 @@ func TestInitQueueHierarchicalPaths(t *testing.T) {
 			// Reset the rotation queue to simulate startup memory state
 			b.credRotationQueue = queue.New()
 
+			// Load managed LDAP users into memory from storage
+			staticRoles, err := b.loadManagedUsers(ictx, config.StorageView)
+			if err != nil {
+				t.Fatal(err)
+			}
+
 			// Now finish the startup process by populating the queue
 			b.initQueue(ictx, &logical.InitializationRequest{
 				Storage: config.StorageView,
-			})
+			}, staticRoles)
 
 			queueLen := b.credRotationQueue.Len()
 			if queueLen != len(tc.roles) {
@@ -379,10 +385,16 @@ func TestStoredWALsCorrectlyProcessed(t *testing.T) {
 			// Reset the rotation queue to simulate startup memory state
 			b.credRotationQueue = queue.New()
 
+			// Load managed LDAP users into memory from storage
+			staticRoles, err := b.loadManagedUsers(ictx, config.StorageView)
+			if err != nil {
+				t.Fatal(err)
+			}
+
 			// Now finish the startup process by populating the queue, which should discard the WAL
 			b.initQueue(ictx, &logical.InitializationRequest{
 				Storage: config.StorageView,
-			})
+			}, staticRoles)
 
 			if tc.shouldRotate {
 				requireWALs(t, config.StorageView, 1)


### PR DESCRIPTION
There is an edge case where a user can add an LDAP user or service account to more than one role or set. This is only possible after the backend has been reloaded.

Roles and sets can be defined as hierarchical paths (i.e. a graph). So we update the initialization path to perform a breadth-first search on the plugin's storage for both roles and sets. If we find an entry, we add it to the managed users map.

We attempt to make as few reads from storage as possible by returning the static roles from the `loadManagedUsers` func and passing them to the `initQueue` function instead of performing another lookup of each node in the graph. We do not want superfluous storage access on plugin initialization which could degrade Vault startup times.