### PR TITLE
Update rotation logic to generate new password when a retried password fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+BUG FIXES:
+
+* Update static role rotation to generate a new password after 2 failed attempts (https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/125)
+
 ## v0.14.3
 
 BUG FIXES:

--- a/rotation.go
+++ b/rotation.go
@@ -321,7 +321,7 @@ func (b *backend) setStaticAccountPassword(ctx context.Context, s logical.Storag
 	}
 
 	var newPassword string
-	var usedExistingWAL bool
+	var usedExistingCredential bool
 	if output.WALID != "" {
 		wal, err := b.findStaticWAL(ctx, s, output.WALID)
 		if err != nil {
@@ -345,7 +345,7 @@ func (b *backend) setStaticAccountPassword(ctx context.Context, s logical.Storag
 		default:
 			// Reuse the password from the existing WAL entry
 			newPassword = wal.NewPassword
-			usedExistingWAL = true
+			usedExistingCredential = true
 		}
 	}
 
@@ -386,7 +386,7 @@ func (b *backend) setStaticAccountPassword(ctx context.Context, s logical.Storag
 		err = b.client.UpdateUserPassword(config.LDAP, input.Role.StaticAccount.Username, newPassword)
 	}
 	if err != nil {
-		if usedExistingWAL {
+		if usedExistingCredential {
 			// A retried password has failed again. Delete WAL and try with fresh password
 			b.Logger().Debug("password stored in WAL failed, deleting WAL", "role", input.RoleName, "WAL ID", output.WALID)
 			if err := framework.DeleteWAL(ctx, s, output.WALID); err != nil {

--- a/rotation.go
+++ b/rotation.go
@@ -321,7 +321,7 @@ func (b *backend) setStaticAccountPassword(ctx context.Context, s logical.Storag
 	}
 
 	var newPassword string
-	var usedExistingCredential bool
+	var usedCredentialFromPreviousRotation bool
 	if output.WALID != "" {
 		wal, err := b.findStaticWAL(ctx, s, output.WALID)
 		if err != nil {
@@ -345,7 +345,7 @@ func (b *backend) setStaticAccountPassword(ctx context.Context, s logical.Storag
 		default:
 			// Reuse the password from the existing WAL entry
 			newPassword = wal.NewPassword
-			usedExistingCredential = true
+			usedCredentialFromPreviousRotation = true
 		}
 	}
 
@@ -386,8 +386,7 @@ func (b *backend) setStaticAccountPassword(ctx context.Context, s logical.Storag
 		err = b.client.UpdateUserPassword(config.LDAP, input.Role.StaticAccount.Username, newPassword)
 	}
 	if err != nil {
-		if usedExistingCredential {
-			// A retried password has failed again. Delete WAL and try with fresh password
+		if usedCredentialFromPreviousRotation {
 			b.Logger().Debug("password stored in WAL failed, deleting WAL", "role", input.RoleName, "WAL ID", output.WALID)
 			if err := framework.DeleteWAL(ctx, s, output.WALID); err != nil {
 				b.Logger().Warn("failed to delete WAL", "error", err, "WAL ID", output.WALID)

--- a/rotation.go
+++ b/rotation.go
@@ -343,6 +343,7 @@ func (b *backend) setStaticAccountPassword(ctx context.Context, s logical.Storag
 			// Generate a new WAL entry and credential
 			output.WALID = ""
 		default:
+			// Reuse the password from the existing WAL entry
 			newPassword = wal.NewPassword
 			usedExistingWAL = true
 		}

--- a/rotation_test.go
+++ b/rotation_test.go
@@ -228,7 +228,7 @@ func TestPasswordPolicyModificationInvalidatesWAL(t *testing.T) {
 		b, storage := getBackend(false)
 		defer b.Cleanup(ctx)
 
-		configureOpenLDAPMountWithPasswordPolicy(t, b, storage, testPasswordPolicy1)
+		configureOpenLDAPMountWithPasswordPolicy(t, b, storage, testPasswordPolicy1, false)
 		createRole(t, b, storage, "hashicorp")
 
 		// Create a WAL entry from a partial failure to rotate
@@ -245,7 +245,7 @@ func TestPasswordPolicyModificationInvalidatesWAL(t *testing.T) {
 		}
 
 		// Update the password policy on the configuration
-		configureOpenLDAPMountWithPasswordPolicy(t, b, storage, testPasswordPolicy2)
+		configureOpenLDAPMountWithPasswordPolicy(t, b, storage, testPasswordPolicy2, false)
 
 		// Manually rotate the role. It should not use the password from the WAL entry
 		// created earlier. Instead, it should result in generation of a new password


### PR DESCRIPTION
# Overview
Previously, when a static role rotation failed, we would store the password in the WAL entry. Upon retries, this same stored password would be reused. This leads customers to infinite loop cases where a failing password is infinitely retried.

This is a workaround for cases where updating the password policy will not help.

# Contributor Checklist
- [x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [x] Backwards compatible


# Testing

```
=== RUN   TestRoles_NewPasswordGeneration
2024-11-20T15:40:14.309-0800 [INFO]  initializing database rotation queue
2024-11-20T15:40:14.310-0800 [INFO]  populating role rotation queue
2024-11-20T15:40:14.310-0800 [DEBUG] no WAL entries found
2024-11-20T15:40:14.310-0800 [INFO]  starting periodic ticker
2024-11-20T15:40:14.310-0800 [DEBUG] wrote WAL: role=hashicorp WAL ID=31031583-48de-c64c-28ec-0a506a06c986
2024-11-20T15:40:14.310-0800 [DEBUG] deleted WAL: WAL ID=31031583-48de-c64c-28ec-0a506a06c986
=== RUN   TestRoles_NewPasswordGeneration/rotation_failures_should_generate_new_password_on_retry
2024-11-20T15:40:14.310-0800 [DEBUG] wrote WAL: role=hashicorp WAL ID=7bcc84df-5a3b-d5d4-31a1-45acbd4af9fa
2024-11-20T15:40:14.310-0800 [WARN]  unable to rotate credentials in rotate-role: error="forced error"
2024-11-20T15:40:14.310-0800 [DEBUG] password stored in WAL failed, generating new password: role=hashicorp WAL ID=7bcc84df-5a3b-d5d4-31a1-45acbd4af9fa
2024-11-20T15:40:14.310-0800 [DEBUG] wrote WAL: role=hashicorp WAL ID=9ae4a137-2029-c4ff-c4a5-cc756bc5d528
2024-11-20T15:40:14.310-0800 [WARN]  unable to rotate credentials in rotate-role: error="forced error"
2024-11-20T15:40:14.310-0800 [DEBUG] password stored in WAL failed, generating new password: role=hashicorp WAL ID=9ae4a137-2029-c4ff-c4a5-cc756bc5d528
2024-11-20T15:40:14.310-0800 [DEBUG] wrote WAL: role=hashicorp WAL ID=6f3ba486-ebf3-bd98-9206-1c6f12990ca6
2024-11-20T15:40:14.310-0800 [DEBUG] deleted WAL: WAL ID=6f3ba486-ebf3-bd98-9206-1c6f12990ca6
--- PASS: TestRoles_NewPasswordGeneration/rotation_failures_should_generate_new_password_on_retry (0.00s)
=== RUN   TestRoles_NewPasswordGeneration/updating_password_policy_should_generate_new_password
2024-11-20T15:40:14.310-0800 [DEBUG] wrote WAL: role=hashicorp WAL ID=41ee98d6-9266-74cc-bce2-5875d2924ec1
2024-11-20T15:40:14.310-0800 [WARN]  unable to rotate credentials in rotate-role: error="forced error"
2024-11-20T15:40:14.310-0800 [DEBUG] password policy changed, generating new password: role=hashicorp WAL ID=41ee98d6-9266-74cc-bce2-5875d2924ec1
2024-11-20T15:40:14.310-0800 [DEBUG] wrote WAL: role=hashicorp WAL ID=4759d581-3a2f-9d1f-201e-e91ad908ed16
2024-11-20T15:40:14.310-0800 [WARN]  unable to rotate credentials in rotate-role: error="forced error"
2024-11-20T15:40:14.310-0800 [DEBUG] password stored in WAL failed, generating new password: role=hashicorp WAL ID=4759d581-3a2f-9d1f-201e-e91ad908ed16
2024-11-20T15:40:14.310-0800 [DEBUG] wrote WAL: role=hashicorp WAL ID=2e9f6355-9322-b5e6-f36b-bd96b8cf8ee5
2024-11-20T15:40:14.310-0800 [DEBUG] deleted WAL: WAL ID=2e9f6355-9322-b5e6-f36b-bd96b8cf8ee5
--- PASS: TestRoles_NewPasswordGeneration/updating_password_policy_should_generate_new_password (0.00s)
--- PASS: TestRoles_NewPasswordGeneration (0.00s)
PASS
```
