### PR TITLE
Backport #125 to `release/vault-1.16.x`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Unreleased
 
+BUG FIXES:
+
+* Update static role rotation to generate a new password after 2 failed attempts (https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/125)
+
+## v0.14.3
+
+BUG FIXES:
+
+* fix an edge case where add an LDAP user or service account can be added to more than one role or set (https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/123)
+
 ## v0.14.2
 
 BUG FIXES:

--- a/path_static_creds_test.go
+++ b/path_static_creds_test.go
@@ -121,3 +121,18 @@ func TestCreds(t *testing.T) {
 		}
 	})
 }
+
+func readStaticCred(t *testing.T, b *backend, storage logical.Storage, roleName string) *logical.Response {
+	t.Helper()
+	req := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      staticCredPath + roleName,
+		Storage:   storage,
+	}
+
+	resp, err := b.HandleRequest(context.Background(), req)
+	if resp == nil || err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+	return resp
+}

--- a/path_static_roles_test.go
+++ b/path_static_roles_test.go
@@ -631,6 +631,112 @@ func TestRoles(t *testing.T) {
 	})
 }
 
+func TestRoles_NewPasswordGeneration(t *testing.T) {
+	ctx := context.Background()
+	b, storage := getBackend(false)
+	defer b.Cleanup(ctx)
+	configureOpenLDAPMount(t, b, storage)
+
+	// Create the role
+	roleName := "hashicorp"
+	createRole(t, b, storage, roleName)
+
+	t.Run("rotation failures should generate new password on retry", func(t *testing.T) {
+		// Fail to rotate the role
+		generateWALFromFailedRotation(t, b, storage, roleName)
+
+		// Get WAL
+		walIDs := requireWALs(t, storage, 1)
+		wal, err := b.findStaticWAL(ctx, storage, walIDs[0])
+		if err != nil || wal == nil {
+			t.Fatal(err)
+		}
+
+		// Store password
+		initialPassword := wal.NewPassword
+
+		// Rotate role manually and fail again with same password
+		generateWALFromFailedRotation(t, b, storage, roleName)
+
+		// Ensure WAL is deleted since retrying initial password failed
+		requireWALs(t, storage, 0)
+
+		// Successfully rotate the role
+		_, err = b.HandleRequest(context.Background(), &logical.Request{
+			Operation: logical.UpdateOperation,
+			Path:      "rotate-role/" + roleName,
+			Storage:   storage,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Ensure WAL is flushed since request was successful
+		requireWALs(t, storage, 0)
+
+		// Read the credential
+		resp := readStaticCred(t, b, storage, roleName)
+
+		// Confirm successful rotation used new credential
+		// Assert previous failing credential is not being used
+		if resp.Data["password"] == initialPassword {
+			t.Fatalf("expected password to be different after second retry")
+		}
+
+	})
+
+	t.Run("updating password policy should generate new password", func(t *testing.T) {
+		// Fail to rotate the role
+		generateWALFromFailedRotation(t, b, storage, roleName)
+
+		// Get WAL
+		walIDs := requireWALs(t, storage, 1)
+		wal, err := b.findStaticWAL(ctx, storage, walIDs[0])
+		if err != nil || wal == nil {
+			t.Fatal(err)
+		}
+
+		expectedPassword := wal.NewPassword
+
+		// Update Password Policy
+		configureOpenLDAPMountWithPasswordPolicy(t, b, storage, testPasswordPolicy1, true)
+
+		// Rotate role manually and fail again
+		generateWALFromFailedRotation(t, b, storage, roleName)
+		// Get WAL
+		walIDs = requireWALs(t, storage, 1)
+		wal, err = b.findStaticWAL(ctx, storage, walIDs[0])
+		if err != nil || wal == nil {
+			t.Fatal(err)
+		}
+
+		// confirm new password is generated and is different from previous password
+		newPassword := wal.NewPassword
+		if expectedPassword == newPassword {
+			t.Fatalf("expected password to be different on second retry")
+		}
+
+		// confirm new password uses policy
+		if newPassword != testPasswordFromPolicy1 {
+			t.Fatalf("expected password %s, got %s", testPasswordFromPolicy1, newPassword)
+		}
+
+		// Successfully rotate the role
+		_, err = b.HandleRequest(context.Background(), &logical.Request{
+			Operation: logical.UpdateOperation,
+			Path:      "rotate-role/" + roleName,
+			Storage:   storage,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Ensure WAL is flushed
+		walIDs = requireWALs(t, storage, 0)
+	})
+
+}
+
 func TestListRoles(t *testing.T) {
 	t.Run("list roles", func(t *testing.T) {
 		b, storage := getBackend(false)
@@ -825,10 +931,10 @@ func TestWALsDeletedOnRoleDeletion(t *testing.T) {
 func configureOpenLDAPMount(t *testing.T, b *backend, storage logical.Storage) {
 	t.Helper()
 
-	configureOpenLDAPMountWithPasswordPolicy(t, b, storage, "")
+	configureOpenLDAPMountWithPasswordPolicy(t, b, storage, "", false)
 }
 
-func configureOpenLDAPMountWithPasswordPolicy(t *testing.T, b *backend, storage logical.Storage, policy string) {
+func configureOpenLDAPMountWithPasswordPolicy(t *testing.T, b *backend, storage logical.Storage, policy string, isUpdate bool) {
 	t.Helper()
 
 	data := map[string]interface{}{
@@ -842,8 +948,12 @@ func configureOpenLDAPMountWithPasswordPolicy(t *testing.T, b *backend, storage 
 		data["password_policy"] = policy
 	}
 
+	operation := logical.CreateOperation
+	if isUpdate {
+		operation = logical.UpdateOperation
+	}
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
-		Operation: logical.CreateOperation,
+		Operation: operation,
 		Path:      configPath,
 		Storage:   storage,
 		Data:      data,

--- a/rotation_test.go
+++ b/rotation_test.go
@@ -143,7 +143,7 @@ func TestPasswordPolicyModificationInvalidatesWAL(t *testing.T) {
 		b, storage := getBackend(false)
 		defer b.Cleanup(ctx)
 
-		configureOpenLDAPMountWithPasswordPolicy(t, b, storage, testPasswordPolicy1)
+		configureOpenLDAPMountWithPasswordPolicy(t, b, storage, testPasswordPolicy1, false)
 		createRole(t, b, storage, "hashicorp")
 
 		// Create a WAL entry from a partial failure to rotate
@@ -160,7 +160,7 @@ func TestPasswordPolicyModificationInvalidatesWAL(t *testing.T) {
 		}
 
 		// Update the password policy on the configuration
-		configureOpenLDAPMountWithPasswordPolicy(t, b, storage, testPasswordPolicy2)
+		configureOpenLDAPMountWithPasswordPolicy(t, b, storage, testPasswordPolicy2, false)
 
 		// Manually rotate the role. It should not use the password from the WAL entry
 		// created earlier. Instead, it should result in generation of a new password


### PR DESCRIPTION
Backport of https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/125 into Vault 1.16.x branch