### PR TITLE
backport/vault-1.17: honor static role ttl across restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## v0.14.4
+
 BUG FIXES:
 
 * Update static role rotation to generate a new password after 2 failed attempts (https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/125)
@@ -36,6 +38,15 @@ BUG FIXES:
   * `golang.org/x/text` v0.14.0 -> v0.18.0
   * `github.com/hashicorp/go-retryablehttp` v0.7.1 -> v0.7.7
 * bump .go-version to 1.22.6
+
+## v0.13.4
+
+BUG FIXES:
+
+* Fix a bug where static role passwords are erroneously rotated across backend restarts when using skip import rotation. (https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/140)
+
+## v0.13.3
+
 
 ## v0.13.2
 

--- a/backend_test.go
+++ b/backend_test.go
@@ -25,8 +25,43 @@ var (
 	testPasswordFromPolicy2 = "TestPolicy2Password"
 )
 
+// getBackend returns an initialized test backend with InmemStorage
 func getBackend(throwsErr bool) (*backend, logical.Storage) {
-	config := &logical.BackendConfig{
+	b, config := getBackendWithConfig(testBackendConfig(), throwsErr)
+	return b, config.StorageView
+}
+
+// getBackendWithConfig returns an initialized test backend for the given
+// config
+func getBackendWithConfig(c *logical.BackendConfig, throwsErr bool) (*backend, *logical.BackendConfig) {
+	b := Backend(&fakeLdapClient{throwErrs: throwsErr})
+	b.Setup(context.Background(), c)
+
+	b.credRotationQueue = queue.New()
+	// Create a context with a cancel method for processing any WAL entries and
+	// populating the queue
+	initCtx := context.Background()
+	ictx, cancel := context.WithCancel(initCtx)
+	b.cancelQueue = cancel
+
+	// Load managed LDAP users into memory from storage
+	staticRoles, err := b.loadManagedUsers(ictx, c.StorageView)
+	if err != nil {
+		// TODO: make this fatal? Requires refactoring all tests to pass in a testing.T
+		b.Logger().Error("error configuring backend: could not read roles from storage")
+	}
+
+	// Load queue and kickoff new periodic ticker
+	b.initQueue(ictx, &logical.InitializationRequest{
+		Storage: c.StorageView,
+	}, staticRoles)
+
+	return b, c
+}
+
+// testBackendConfig returns a backend config with inmem storage
+func testBackendConfig() *logical.BackendConfig {
+	return &logical.BackendConfig{
 		Logger: logging.NewVaultLogger(log.Debug),
 
 		System: &logical.StaticSystemView{
@@ -43,23 +78,6 @@ func getBackend(throwsErr bool) (*backend, logical.Storage) {
 		},
 		StorageView: &logical.InmemStorage{},
 	}
-
-	b := Backend(&fakeLdapClient{throwErrs: throwsErr})
-	b.Setup(context.Background(), config)
-
-	b.credRotationQueue = queue.New()
-	// Create a context with a cancel method for processing any WAL entries and
-	// populating the queue
-	initCtx := context.Background()
-	ictx, cancel := context.WithCancel(initCtx)
-	b.cancelQueue = cancel
-
-	// Load queue and kickoff new periodic ticker
-	b.initQueue(ictx, &logical.InitializationRequest{
-		Storage: config.StorageView,
-	}, nil)
-
-	return b, config.StorageView
 }
 
 var _ ldapClient = (*fakeLdapClient)(nil)

--- a/path_static_roles.go
+++ b/path_static_roles.go
@@ -323,16 +323,30 @@ func (b *backend) pathStaticRoleCreateUpdate(ctx context.Context, req *logical.R
 		skipRotation = c.SkipStaticRoleImportRotation
 	}
 
-	// lvr represents the role's LastVaultRotation
-	lvr := role.StaticAccount.LastVaultRotation
+	lastVaultRotation := role.StaticAccount.LastVaultRotation
 
 	// Only call setStaticAccountPassword if we're creating the role for the first time
 	var item *queue.Item
 	switch req.Operation {
 	case logical.CreateOperation:
-		// if we were asked to not rotate, just add the entry - this essentially becomes an update operation, except
-		// the item is new
 		if skipRotation {
+			b.Logger().Debug("skipping static role import rotation", "role", name)
+
+			// Synthetically set lastVaultRotation to now so that it gets
+			// queued correctly.
+			// NOTE: We intentionally do not set role.StaticAccount.LastVaultRotation
+			// because the zero value indicates Vault has not rotated the
+			// password yet.
+			lastVaultRotation = time.Now()
+
+			// NextVaultRotation allows calculating the TTL on GET /static-creds
+			// requests and to calculate the queue priority in populateQueue()
+			// across restarts. We can't rely on LastVaultRotation in these
+			// cases because, when import rotation is skipped, LastVaultRotation
+			// is set to a zero value in storage.
+			role.StaticAccount.SetNextVaultRotation(lastVaultRotation)
+
+			// we were told not to rotate, just add the entry
 			entry, err := logical.StorageEntryJSON(staticRolePath+name, role)
 			if err != nil {
 				return nil, err
@@ -345,8 +359,6 @@ func (b *backend) pathStaticRoleCreateUpdate(ctx context.Context, req *logical.R
 			item = &queue.Item{
 				Key: name,
 			}
-			// synthetically set lvr to now, so that it gets queued correctly
-			lvr = time.Now()
 			break
 		} else {
 			// setStaticAccountPassword calls Storage.Put and saves the role to storage
@@ -369,7 +381,7 @@ func (b *backend) pathStaticRoleCreateUpdate(ctx context.Context, req *logical.R
 				return nil, err
 			}
 			// guard against RotationTime not being set or zero-value
-			lvr = resp.RotationTime
+			lastVaultRotation = resp.RotationTime
 			item = &queue.Item{
 				Key: name,
 			}
@@ -394,7 +406,7 @@ func (b *backend) pathStaticRoleCreateUpdate(ctx context.Context, req *logical.R
 		}
 	}
 
-	item.Priority = lvr.Add(role.StaticAccount.RotationPeriod).Unix()
+	item.Priority = lastVaultRotation.Add(role.StaticAccount.RotationPeriod).Unix()
 
 	// Add their rotation to the queue
 	if err := b.pushItem(item); err != nil {
@@ -426,8 +438,13 @@ type staticAccount struct {
 	// This is returned on credential requests if it exists.
 	LastPassword string `json:"last_password"`
 
-	// LastVaultRotation represents the last time Vault rotated the password
+	// LastVaultRotation represents the last time Vault rotated the password. A
+	// zero value indicates the the password has never been rotated by Vault.
 	LastVaultRotation time.Time `json:"last_vault_rotation"`
+
+	// NextVaultRotation represents the next time Vault is expected to rotate
+	// the password
+	NextVaultRotation time.Time `json:"next_vault_rotation"`
 
 	// RotationPeriod is number in seconds between each rotation, effectively a
 	// "time to live". This value is compared to the LastVaultRotation to
@@ -438,7 +455,13 @@ type staticAccount struct {
 // NextRotationTime calculates the next rotation by adding the Rotation Period
 // to the last known vault rotation
 func (s *staticAccount) NextRotationTime() time.Time {
-	return s.LastVaultRotation.Add(s.RotationPeriod)
+	return s.NextVaultRotation
+}
+
+// SetNextVaultRotation sets the next vault rotation to time t plus the role's
+// rotation period.
+func (s *staticAccount) SetNextVaultRotation(t time.Time) {
+	s.NextVaultRotation = t.Add(s.RotationPeriod)
 }
 
 // PasswordTTL calculates the approximate time remaining until the password is

--- a/rotation.go
+++ b/rotation.go
@@ -403,6 +403,7 @@ func (b *backend) setStaticAccountPassword(ctx context.Context, s logical.Storag
 	// lvr is the known LastVaultRotation
 	lvr := time.Now()
 	input.Role.StaticAccount.LastVaultRotation = lvr
+	input.Role.StaticAccount.SetNextVaultRotation(lvr)
 	input.Role.StaticAccount.LastPassword = input.Role.StaticAccount.Password
 	input.Role.StaticAccount.Password = newPassword
 	output.RotationTime = lvr

--- a/rotation_test.go
+++ b/rotation_test.go
@@ -55,45 +55,18 @@ func TestInitQueueHierarchicalPaths(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
-			config := &logical.BackendConfig{
-				Logger: logging.NewVaultLogger(log.Debug),
+			b, config := getBackendWithConfig(testBackendConfig(), false)
+			defer b.Cleanup(context.Background())
+			storage := config.StorageView
 
-				System: &logical.StaticSystemView{
-					DefaultLeaseTTLVal: defaultLeaseTTLVal,
-					MaxLeaseTTLVal:     maxLeaseTTLVal,
-				},
-				StorageView: &logical.InmemStorage{},
-			}
-
-			b := Backend(&fakeLdapClient{throwErrs: false})
-			b.Setup(context.Background(), config)
-
-			b.credRotationQueue = queue.New()
-			initCtx := context.Background()
-			ictx, cancel := context.WithCancel(initCtx)
-			b.cancelQueue = cancel
-
-			defer b.Cleanup(ctx)
-			configureOpenLDAPMount(t, b, config.StorageView)
+			configureOpenLDAPMount(t, b, storage)
 
 			for _, r := range tc.roles {
 				createRole(t, b, config.StorageView, r)
 			}
 
-			// Reset the rotation queue to simulate startup memory state
-			b.credRotationQueue = queue.New()
-
-			// Load managed LDAP users into memory from storage
-			staticRoles, err := b.loadManagedUsers(ictx, config.StorageView)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			// Now finish the startup process by populating the queue
-			b.initQueue(ictx, &logical.InitializationRequest{
-				Storage: config.StorageView,
-			}, staticRoles)
+			// Reload backend to similate a Vault restart/startup memory state
+			getBackendWithConfig(config, false)
 
 			queueLen := b.credRotationQueue.Len()
 			if queueLen != len(tc.roles) {
@@ -201,6 +174,78 @@ func TestAutoRotate(t *testing.T) {
 		}
 		if oldPassword != resp.Data["last_password"] {
 			t.Fatal("expected last_password to be equal to old password after auto rotation")
+		}
+	})
+
+	t.Run("skip_import_rotation is true and rotates after ttl expiration", func(t *testing.T) {
+		b, storage := getBackend(false)
+		defer b.Cleanup(context.Background())
+
+		configureOpenLDAPMount(t, b, storage)
+
+		data := map[string]interface{}{
+			"username":             "hashicorp",
+			"dn":                   "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
+			"rotation_period":      "5s",
+			"skip_import_rotation": true,
+		}
+
+		roleName := "hashicorp"
+		createStaticRoleWithData(t, b, storage, roleName, data)
+		resp := readStaticCred(t, b, storage, roleName)
+
+		if resp.Data["password"] != "" {
+			t.Fatal("expected password to be empty, it wasn't: skip_import_rotation was enabled, password should not be rotated on import")
+		}
+
+		// Wait for auto rotation (5s) + 1 second for breathing room
+		time.Sleep(time.Second * 6)
+
+		resp = readStaticCred(t, b, storage, roleName)
+
+		if resp.Data["password"] == "" {
+			t.Fatal("expected password to be set after auto rotation, it wasn't")
+		}
+		if resp.Data["last_password"] != "" {
+			t.Fatal("expected last_password to be empty after auto rotation, it wasn't")
+		}
+	})
+
+	t.Run("skip_import_rotation is true and does not rotate after backend reload", func(t *testing.T) {
+		b, config := getBackendWithConfig(testBackendConfig(), false)
+		defer b.Cleanup(context.Background())
+		storage := config.StorageView
+
+		configureOpenLDAPMount(t, b, storage)
+
+		data := map[string]interface{}{
+			"username":             "hashicorp",
+			"dn":                   "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
+			"rotation_period":      "10m",
+			"skip_import_rotation": true,
+		}
+
+		roleName := "hashicorp"
+		createStaticRoleWithData(t, b, storage, roleName, data)
+		resp := readStaticCred(t, b, storage, roleName)
+
+		if resp.Data["password"] != "" {
+			t.Fatal("expected password to be empty, it wasn't: skip_import_rotation was enabled, password should not be rotated on import")
+		}
+		if resp.Data["last_password"] != "" {
+			t.Fatal("expected last_password to be empty, it wasn't")
+		}
+
+		// Reload backend to similate a Vault restart/startup memory state
+		getBackendWithConfig(config, false)
+
+		resp = readStaticCred(t, b, storage, roleName)
+
+		if resp.Data["password"] != "" {
+			t.Fatal("expected password to be empty after backend reload, it wasn't: skip_import_rotation was enabled, password should not be rotated yet")
+		}
+		if resp.Data["last_password"] != "" {
+			t.Fatal("expected last_password to be empty after backend reload, it wasn't")
 		}
 	})
 }


### PR DESCRIPTION
Backport of https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/140

This is being backported to the plugin's `release/vault-1.17.x` branch and will be released as `v0.13.4` of the plugin