### PR TITLE
update for sdk changes

### DIFF
--- a/backend_test.go
+++ b/backend_test.go
@@ -6,8 +6,9 @@ package openldap
 import (
 	"context"
 	"errors"
-	"github.com/hashicorp/vault/sdk/helper/automatedrotationutil"
 	"time"
+
+	"github.com/hashicorp/vault/sdk/helper/automatedrotationutil"
 
 	"github.com/hashicorp/vault/sdk/rotation"
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.9
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2
 	github.com/hashicorp/vault/api v1.16.0
-	github.com/hashicorp/vault/sdk v0.15.1
+	github.com/hashicorp/vault/sdk v0.15.2
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/ory/dockertest/v3 v3.11.0
 	github.com/stretchr/testify v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.9
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2
 	github.com/hashicorp/vault/api v1.16.0
-	github.com/hashicorp/vault/sdk v0.15.0
+	github.com/hashicorp/vault/sdk v0.15.1-0.20250221185133-d0618a6ce555
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/ory/dockertest/v3 v3.11.0
 	github.com/stretchr/testify v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.9
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2
 	github.com/hashicorp/vault/api v1.16.0
-	github.com/hashicorp/vault/sdk v0.15.1-0.20250221185133-d0618a6ce555
+	github.com/hashicorp/vault/sdk v0.15.1
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/ory/dockertest/v3 v3.11.0
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,8 @@ github.com/hashicorp/hcl v1.0.1-vault-5 h1:kI3hhbbyzr4dldA8UdTb7ZlVVlI2DACdCfz31
 github.com/hashicorp/hcl v1.0.1-vault-5/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=
 github.com/hashicorp/vault/api v1.16.0 h1:nbEYGJiAPGzT9U4oWgaaB0g+Rj8E59QuHKyA5LhwQN4=
 github.com/hashicorp/vault/api v1.16.0/go.mod h1:KhuUhzOD8lDSk29AtzNjgAu2kxRA9jL9NAbkFlqvkBA=
-github.com/hashicorp/vault/sdk v0.15.1 h1:Y8CkijkR2UfFfVLO4J58JP4A4NAaxvafyjlZvzt0hu4=
-github.com/hashicorp/vault/sdk v0.15.1/go.mod h1:2Wj2tHIgfz0gNWgEPWBbCXFIiPrq96E8FTjPNV9J1Bc=
+github.com/hashicorp/vault/sdk v0.15.2 h1:Rp5Yp4lyBhlWgq24ZVb2n/YN47RKOAvmx/jlMfS9ku4=
+github.com/hashicorp/vault/sdk v0.15.2/go.mod h1:2Wj2tHIgfz0gNWgEPWBbCXFIiPrq96E8FTjPNV9J1Bc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/jcmturner/aescts/v2 v2.0.0 h1:9YKLH6ey7H4eDBXW8khjYslgyqG2xZikXP0EQFKrle8=

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,8 @@ github.com/hashicorp/hcl v1.0.1-vault-5 h1:kI3hhbbyzr4dldA8UdTb7ZlVVlI2DACdCfz31
 github.com/hashicorp/hcl v1.0.1-vault-5/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=
 github.com/hashicorp/vault/api v1.16.0 h1:nbEYGJiAPGzT9U4oWgaaB0g+Rj8E59QuHKyA5LhwQN4=
 github.com/hashicorp/vault/api v1.16.0/go.mod h1:KhuUhzOD8lDSk29AtzNjgAu2kxRA9jL9NAbkFlqvkBA=
-github.com/hashicorp/vault/sdk v0.15.1-0.20250221185133-d0618a6ce555 h1:5VS5U0Ps4vQaCCJCp/o1LMnmEn/TF6rZnCm+9Hnl1dE=
-github.com/hashicorp/vault/sdk v0.15.1-0.20250221185133-d0618a6ce555/go.mod h1:2Wj2tHIgfz0gNWgEPWBbCXFIiPrq96E8FTjPNV9J1Bc=
+github.com/hashicorp/vault/sdk v0.15.1 h1:Y8CkijkR2UfFfVLO4J58JP4A4NAaxvafyjlZvzt0hu4=
+github.com/hashicorp/vault/sdk v0.15.1/go.mod h1:2Wj2tHIgfz0gNWgEPWBbCXFIiPrq96E8FTjPNV9J1Bc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/jcmturner/aescts/v2 v2.0.0 h1:9YKLH6ey7H4eDBXW8khjYslgyqG2xZikXP0EQFKrle8=

--- a/go.sum
+++ b/go.sum
@@ -192,6 +192,8 @@ github.com/hashicorp/vault/api v1.16.0 h1:nbEYGJiAPGzT9U4oWgaaB0g+Rj8E59QuHKyA5L
 github.com/hashicorp/vault/api v1.16.0/go.mod h1:KhuUhzOD8lDSk29AtzNjgAu2kxRA9jL9NAbkFlqvkBA=
 github.com/hashicorp/vault/sdk v0.15.0 h1:xNo1lL2shm0yE4coXNZkTV/6++2GfEh+/cCAfBjzEnA=
 github.com/hashicorp/vault/sdk v0.15.0/go.mod h1:2Wj2tHIgfz0gNWgEPWBbCXFIiPrq96E8FTjPNV9J1Bc=
+github.com/hashicorp/vault/sdk v0.15.1-0.20250221185133-d0618a6ce555 h1:5VS5U0Ps4vQaCCJCp/o1LMnmEn/TF6rZnCm+9Hnl1dE=
+github.com/hashicorp/vault/sdk v0.15.1-0.20250221185133-d0618a6ce555/go.mod h1:2Wj2tHIgfz0gNWgEPWBbCXFIiPrq96E8FTjPNV9J1Bc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/jcmturner/aescts/v2 v2.0.0 h1:9YKLH6ey7H4eDBXW8khjYslgyqG2xZikXP0EQFKrle8=

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,6 @@ github.com/hashicorp/hcl v1.0.1-vault-5 h1:kI3hhbbyzr4dldA8UdTb7ZlVVlI2DACdCfz31
 github.com/hashicorp/hcl v1.0.1-vault-5/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=
 github.com/hashicorp/vault/api v1.16.0 h1:nbEYGJiAPGzT9U4oWgaaB0g+Rj8E59QuHKyA5LhwQN4=
 github.com/hashicorp/vault/api v1.16.0/go.mod h1:KhuUhzOD8lDSk29AtzNjgAu2kxRA9jL9NAbkFlqvkBA=
-github.com/hashicorp/vault/sdk v0.15.0 h1:xNo1lL2shm0yE4coXNZkTV/6++2GfEh+/cCAfBjzEnA=
-github.com/hashicorp/vault/sdk v0.15.0/go.mod h1:2Wj2tHIgfz0gNWgEPWBbCXFIiPrq96E8FTjPNV9J1Bc=
 github.com/hashicorp/vault/sdk v0.15.1-0.20250221185133-d0618a6ce555 h1:5VS5U0Ps4vQaCCJCp/o1LMnmEn/TF6rZnCm+9Hnl1dE=
 github.com/hashicorp/vault/sdk v0.15.1-0.20250221185133-d0618a6ce555/go.mod h1:2Wj2tHIgfz0gNWgEPWBbCXFIiPrq96E8FTjPNV9J1Bc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=

--- a/path_config.go
+++ b/path_config.go
@@ -204,7 +204,7 @@ func (b *backend) configCreateUpdateOperation(ctx context.Context, req *logical.
 	// set up rotation after everything is fine
 	var rotOp string
 	if conf.ShouldDeregisterRotationJob() {
-		rotOp = "deregistration"
+		rotOp = rotation.PerformedDeregistration
 		deregisterReq := &rotation.RotationJobDeregisterRequest{
 			MountPoint: req.MountPoint,
 			ReqPath:    req.Path,
@@ -214,7 +214,7 @@ func (b *backend) configCreateUpdateOperation(ctx context.Context, req *logical.
 			return logical.ErrorResponse("error de-registering rotation job: %s", err), nil
 		}
 	} else if conf.ShouldRegisterRotationJob() {
-		rotOp = "registration"
+		rotOp = rotation.PerformedRegistration
 		req := &rotation.RotationJobConfigureRequest{
 			Name:             rootRotationJobName,
 			MountPoint:       req.MountPoint,

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -644,9 +644,9 @@ func ldapResponseData(vals ...interface{}) map[string]interface{} {
 		"userdn":                           "",
 		"userfilter":                       "({{.UserAttr}}={{.Username}})",
 		"username_as_alias":                false,
-		"rotation_period":                  0,
+		"rotation_period":                  float64(0),
 		"rotation_schedule":                "",
-		"rotation_window":                  0,
+		"rotation_window":                  float64(0),
 		"disable_automated_rotation":       false,
 		"enable_samaccountname_login":      false,
 	}


### PR DESCRIPTION
This PR updates the tests to work with the new expanded values for rotation period and rotation window (now durations)

I'm doing this in advance of the new SDK being tagged for time-efficiency reasons, but before this PR is merged, it will have to be pinned to the new (presumably 0.15.1) of the vault SDK.