### PR TITLE
Fix issue where roles created before 0.14.5 had a nil NextVaultRotation value #VAULT-35117 (#156)

### DIFF
--- a/path_static_roles.go
+++ b/path_static_roles.go
@@ -390,6 +390,14 @@ func (b *backend) pathStaticRoleCreateUpdate(ctx context.Context, req *logical.R
 			}
 		}
 	case logical.UpdateOperation:
+		// if lastVaultRotation is zero, the role had `skip_import_rotation` set
+		if lastVaultRotation.IsZero() {
+			lastVaultRotation = time.Now()
+		}
+
+		// Ensure that NextVaultRotation is recalculated in case the rotation period changed
+		role.StaticAccount.SetNextVaultRotation(lastVaultRotation)
+
 		// store updated Role
 		entry, err := logical.StorageEntryJSON(staticRolePath+name, role)
 		if err != nil {
@@ -408,8 +416,7 @@ func (b *backend) pathStaticRoleCreateUpdate(ctx context.Context, req *logical.R
 			return nil, err
 		}
 	}
-
-	item.Priority = lastVaultRotation.Add(role.StaticAccount.RotationPeriod).Unix()
+	item.Priority = role.StaticAccount.NextVaultRotation.Unix()
 
 	// Add their rotation to the queue
 	if err := b.pushItem(item); err != nil {

--- a/path_static_roles_test.go
+++ b/path_static_roles_test.go
@@ -792,6 +792,19 @@ func createStaticRoleWithData(t *testing.T, b *backend, s logical.Storage, name 
 	return b.HandleRequest(context.Background(), req)
 }
 
+func updateStaticRoleWithData(t *testing.T, b *backend, s logical.Storage, name string, d map[string]interface{}) (*logical.Response, error) {
+	t.Helper()
+
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      staticRolePath + name,
+		Storage:   s,
+		Data:      d,
+	}
+
+	return b.HandleRequest(context.Background(), req)
+}
+
 func readStaticRole(t *testing.T, b *backend, storage logical.Storage, roleName string) (*logical.Response, error) {
 	req := &logical.Request{
 		Operation: logical.ReadOperation,

--- a/rotation.go
+++ b/rotation.go
@@ -55,6 +55,30 @@ func (b *backend) populateQueue(ctx context.Context, s logical.Storage, roles ma
 			continue
 		}
 
+		// If an account's NextVaultRotation period is nil, it means that the
+		// role was created before we added the `NextVaultRotation` field. In this
+		// case, we need to calculate the next rotation time based on the
+		// LastVaultRotation and the RotationPeriod. However, if the role was
+		// created with skip_import_rotation set, we need to use the current time
+		// instead of LastVaultRotation because LastVaultRotation is 0
+		// This situation was fixed by https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/140.
+		if role.StaticAccount.NextVaultRotation.IsZero() {
+			log.Debug("NextVaultRotation is zero", roleName)
+			// Previously skipped import rotation roles had a LastVaultRotation value of zero
+			if role.StaticAccount.LastVaultRotation.IsZero() {
+				role.StaticAccount.SetNextVaultRotation(time.Now())
+			} else {
+				role.StaticAccount.SetNextVaultRotation(role.StaticAccount.LastVaultRotation)
+			}
+
+			entry, err := logical.StorageEntryJSON(staticRolePath+roleName, role)
+			if err != nil {
+				log.Warn("failed to build write storage entry", "error", err, "roleName", roleName)
+			} else if err := s.Put(ctx, entry); err != nil {
+				log.Warn("failed to write storage entry", "error", err, "roleName", roleName)
+			}
+		}
+
 		item := queue.Item{
 			Key:      roleName,
 			Priority: role.StaticAccount.NextRotationTime().Unix(),

--- a/rotation_test.go
+++ b/rotation_test.go
@@ -239,6 +239,9 @@ func TestAutoRotate(t *testing.T) {
 		// Reload backend to similate a Vault restart/startup memory state
 		getBackendWithConfig(config, false)
 
+		// Wait for auto rotation (5s) + 1 second for breathing room
+		time.Sleep(time.Second * 6)
+
 		resp = readStaticCred(t, b, storage, roleName)
 
 		if resp.Data["password"] != "" {
@@ -246,6 +249,188 @@ func TestAutoRotate(t *testing.T) {
 		}
 		if resp.Data["last_password"] != "" {
 			t.Fatal("expected last_password to be empty after backend reload, it wasn't")
+		}
+	})
+
+	t.Run("skip_import_rotation is true and update does not rotate", func(t *testing.T) {
+		b, config := getBackendWithConfig(testBackendConfig(), false)
+		defer b.Cleanup(context.Background())
+		storage := config.StorageView
+
+		configureOpenLDAPMount(t, b, storage)
+
+		data := map[string]interface{}{
+			"username":             "hashicorp",
+			"dn":                   "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
+			"rotation_period":      "10m",
+			"skip_import_rotation": true,
+		}
+
+		roleName := "hashicorp"
+		fmt.Println(">>> creating static role")
+		_, err := createStaticRoleWithData(t, b, storage, roleName, data)
+		require.NoError(t, err)
+
+		data = map[string]interface{}{
+			"rotation_period": "5m",
+		}
+
+		time.Sleep(time.Second * 6)
+		fmt.Println(">>> updating static role")
+		_, err = updateStaticRoleWithData(t, b, storage, roleName, data)
+		require.NoError(t, err)
+
+		// Wait for auto rotation (5s) + 1 second for breathing room
+		time.Sleep(time.Second * 6)
+
+		resp := readStaticCred(t, b, storage, roleName)
+
+		if resp.Data["password"] != "" {
+			t.Fatal("expected password to be empty after backend reload, it wasn't: skip_import_rotation was enabled, password should not be rotated yet")
+		}
+		if resp.Data["last_password"] != "" {
+			t.Fatal("expected last_password to be empty after backend reload, it wasn't")
+		}
+	})
+
+	t.Run("NextVaultRotation is properly persisted on update", func(t *testing.T) {
+		b, config := getBackendWithConfig(testBackendConfig(), false)
+		defer b.Cleanup(context.Background())
+		storage := config.StorageView
+
+		configureOpenLDAPMount(t, b, storage)
+
+		roleName := "hashicorp"
+		data := map[string]interface{}{
+			"username":             roleName,
+			"dn":                   "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
+			"rotation_period":      "1h",
+			"skip_import_rotation": true,
+		}
+
+		_, err := createStaticRoleWithData(t, b, storage, roleName, data)
+		require.NoError(t, err)
+
+		originalRole, err := b.staticRole(context.Background(), storage, roleName)
+		if err != nil {
+			t.Fatal("failed to fetch static role", err)
+		}
+
+		// Update static role's rotation period to 5m
+		data = map[string]interface{}{
+			"rotation_period": "5m",
+		}
+		_, err = updateStaticRoleWithData(t, b, storage, roleName, data)
+		require.NoError(t, err)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+		updatedRole, err := b.staticRole(context.Background(), storage, roleName)
+		if err != nil {
+			t.Fatal("failed to fetch static role", err)
+		}
+
+		if originalRole.StaticAccount.NextVaultRotation.Equal(updatedRole.StaticAccount.NextVaultRotation) {
+			t.Fatal("expected nextVaultRotation1 to be different from nextVaultRotation2")
+		}
+	})
+
+	// This is to test static roles created before 0.14.5
+	// In 0.14.5, vault started persisting `NextVaultRotation`
+	t.Run("zero NextVaultRotation does not cause rotate after backend reload", func(t *testing.T) {
+		b, config := getBackendWithConfig(testBackendConfig(), false)
+		defer b.Cleanup(context.Background())
+		storage := config.StorageView
+
+		configureOpenLDAPMount(t, b, storage)
+
+		roleName := "hashicorp"
+		data := map[string]interface{}{
+			"username":             roleName,
+			"dn":                   "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
+			"rotation_period":      "10m",
+			"skip_import_rotation": true,
+		}
+
+		createStaticRoleWithData(t, b, storage, roleName, data)
+		resp := readStaticCred(t, b, storage, roleName)
+		firstRotation := resp.Data["last_vault_rotation"].(time.Time)
+
+		// force NextVaultRotation to zero to simulate roles before 0.14.5 fix
+		role, err := b.staticRole(context.Background(), storage, roleName)
+		if err != nil {
+			t.Fatal("failed to fetch static role", err)
+		}
+		role.StaticAccount.NextVaultRotation = time.Time{}
+		entry, err := logical.StorageEntryJSON(staticRolePath+roleName, role)
+		if err != nil {
+			t.Fatal("failed to build role for storage", err)
+		}
+		if err := storage.Put(context.Background(), entry); err != nil {
+			t.Fatal("failed to write role to storage", err)
+		}
+
+		// Reload backend to similate a Vault restart/startup memory state
+		getBackendWithConfig(config, false)
+
+		// TODO: this is hacky because the queue ticker runs every 5 seconds
+		time.Sleep(8 * time.Second)
+		resp = readStaticCred(t, b, storage, roleName)
+		secondRotation := resp.Data["last_vault_rotation"].(time.Time)
+
+		// check if first rotation is different from second rotation
+		if !firstRotation.Equal(secondRotation) {
+			t.Fatal("expected first rotation to be equal to second rotation to prove that credential wasnt rotated")
+		}
+	})
+
+	// This is to test static roles created before 0.14.5
+	// In 0.14.5, vault started persisting `NextVaultRotation`
+	t.Run("zero NextVaultRotation for a static role with `skip_import_rotation` does not cause rotate after backend reload", func(t *testing.T) {
+		b, config := getBackendWithConfig(testBackendConfig(), false)
+		defer b.Cleanup(context.Background())
+		storage := config.StorageView
+
+		configureOpenLDAPMount(t, b, storage)
+
+		roleName := "hashicorp"
+		data := map[string]interface{}{
+			"username":             roleName,
+			"dn":                   "uid=hashicorp,ou=users,dc=hashicorp,dc=com",
+			"rotation_period":      "10m",
+			"skip_import_rotation": true,
+		}
+
+		createStaticRoleWithData(t, b, storage, roleName, data)
+		resp := readStaticCred(t, b, storage, roleName)
+		firstRotation := resp.Data["last_vault_rotation"].(time.Time)
+
+		// force NextVaultRotation to zero to simulate roles before 0.14.5 fix
+		role, err := b.staticRole(context.Background(), storage, roleName)
+		if err != nil {
+			t.Fatal("failed to fetch static role", err)
+		}
+		role.StaticAccount.NextVaultRotation = time.Time{}
+		entry, err := logical.StorageEntryJSON(staticRolePath+roleName, role)
+		if err != nil {
+			t.Fatal("failed to build role for storage", err)
+		}
+		if err := storage.Put(context.Background(), entry); err != nil {
+			t.Fatal("failed to write role to storage", err)
+		}
+
+		// Reload backend to similate a Vault restart/startup memory state
+		getBackendWithConfig(config, false)
+
+		// TODO: this is hacky because the queue ticker runs every 5 seconds
+		time.Sleep(8 * time.Second)
+		resp = readStaticCred(t, b, storage, roleName)
+		secondRotation := resp.Data["last_vault_rotation"].(time.Time)
+
+		// check if first rotation is different from second rotation
+		if !firstRotation.Equal(secondRotation) {
+			t.Fatal("expected first rotation to be equal to second rotation to prove that credential wasnt rotated")
 		}
 	})
 }


### PR DESCRIPTION
Backport of https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/156

---------

# Overview
A high level description of the contribution, including:
Who the change affects or is for (stakeholders)?
What is the change?
Why is the change needed?
How does this change affect the user experience (if at all)?

# Related Issues/Pull Requests
- [ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
- [ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [ ] Backwards compatible
