### PR TITLE
Fix issue where roles created before 0.14.5 had a nil NextVaultRotation value #VAULT-35117 (#156)

### DIFF
--- a/path_static_roles.go
+++ b/path_static_roles.go
@@ -366,6 +366,14 @@ func (b *backend) pathStaticRoleCreateUpdate(ctx context.Context, req *logical.R
 			}
 		}
 	case logical.UpdateOperation:
+		// if lastVaultRotation is zero, the role had `skip_import_rotation` set
+		if lastVaultRotation.IsZero() {
+			lastVaultRotation = time.Now()
+		}
+
+		// Ensure that NextVaultRotation is recalculated in case the rotation period changed
+		role.StaticAccount.SetNextVaultRotation(lastVaultRotation)
+
 		// store updated Role
 		entry, err := logical.StorageEntryJSON(staticRolePath+name, role)
 		if err != nil {
@@ -384,8 +392,7 @@ func (b *backend) pathStaticRoleCreateUpdate(ctx context.Context, req *logical.R
 			return nil, err
 		}
 	}
-
-	item.Priority = lastVaultRotation.Add(role.StaticAccount.RotationPeriod).Unix()
+	item.Priority = role.StaticAccount.NextVaultRotation.Unix()
 
 	// Add their rotation to the queue
 	if err := b.pushItem(item); err != nil {

--- a/rotation.go
+++ b/rotation.go
@@ -62,6 +62,30 @@ func (b *backend) populateQueue(ctx context.Context, s logical.Storage) {
 			continue
 		}
 
+		// If an account's NextVaultRotation period is nil, it means that the
+		// role was created before we added the `NextVaultRotation` field. In this
+		// case, we need to calculate the next rotation time based on the
+		// LastVaultRotation and the RotationPeriod. However, if the role was
+		// created with skip_import_rotation set, we need to use the current time
+		// instead of LastVaultRotation because LastVaultRotation is 0
+		// This situation was fixed by https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/140.
+		if role.StaticAccount.NextVaultRotation.IsZero() {
+			log.Debug("NextVaultRotation is zero", roleName)
+			// Previously skipped import rotation roles had a LastVaultRotation value of zero
+			if role.StaticAccount.LastVaultRotation.IsZero() {
+				role.StaticAccount.SetNextVaultRotation(time.Now())
+			} else {
+				role.StaticAccount.SetNextVaultRotation(role.StaticAccount.LastVaultRotation)
+			}
+
+			entry, err := logical.StorageEntryJSON(staticRolePath+roleName, role)
+			if err != nil {
+				log.Warn("failed to build write storage entry", "error", err, "roleName", roleName)
+			} else if err := s.Put(ctx, entry); err != nil {
+				log.Warn("failed to write storage entry", "error", err, "roleName", roleName)
+			}
+		}
+
 		item := queue.Item{
 			Key:      roleName,
 			Priority: role.StaticAccount.NextRotationTime().Unix(),


### PR DESCRIPTION
Backport of https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/156

---------

# Overview
A high level description of the contribution, including:
Who the change affects or is for (stakeholders)?
What is the change?
Why is the change needed?
How does this change affect the user experience (if at all)?

# Related Issues/Pull Requests
- [ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
- [ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [ ] Backwards compatible
