### PR TITLE
Support RACF password phrase management for static roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+FEATURES:
+* Support RACF password phrase management for static roles (https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/184)
+
 ## v0.16.0
 ### June 4, 2025
 

--- a/client.go
+++ b/client.go
@@ -55,7 +55,7 @@ func (c *Client) UpdateDNPassword(conf *client.Config, dn string, newPassword st
 		dn = conf.UserDN
 	}
 
-	newValues, err := client.GetSchemaFieldRegistry(conf.Schema, newPassword)
+	newValues, err := client.GetSchemaFieldRegistry(conf, newPassword)
 	if err != nil {
 		return fmt.Errorf("error updating password: %s", err)
 	}
@@ -79,7 +79,7 @@ func (c *Client) UpdateUserPassword(conf *client.Config, username string, newPas
 		field: {username},
 	}
 
-	newValues, err := client.GetSchemaFieldRegistry(conf.Schema, newPassword)
+	newValues, err := client.GetSchemaFieldRegistry(conf, newPassword)
 	if err != nil {
 		return fmt.Errorf("error updating password: %s", err)
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -20,11 +20,12 @@ import (
 
 type Config struct {
 	*ldaputil.ConfigEntry
-	// CredentialType specifies the type of credential to generate for the Schema
-	CredentialType           CredentialType `json:"credential_type"`
-	LastBindPassword         string         `json:"last_bind_password"`
-	LastBindPasswordRotation time.Time      `json:"last_bind_password_rotation"`
-	Schema                   string         `json:"schema"`
+	LastBindPassword         string    `json:"last_bind_password"`
+	LastBindPasswordRotation time.Time `json:"last_bind_password_rotation"`
+	Schema                   string    `json:"schema"`
+
+	// CredentialType is used to customize the Schema. Currently only used for type racf.
+	CredentialType CredentialType `json:"credential_type"`
 }
 
 func New(logger hclog.Logger) Client {
@@ -277,38 +278,4 @@ func errorf(format string, wrappedErr error) error {
 	}
 
 	return fmt.Errorf(format, wrappedErr)
-}
-
-// CredentialType is a type of database credential.
-type CredentialType int
-
-const (
-	CredentialTypeUnknown CredentialType = iota
-	CredentialTypePassword
-	CredentialTypePhrase
-)
-
-func (c CredentialType) String() string {
-	switch c {
-	case CredentialTypePassword:
-		return "password"
-	case CredentialTypePhrase:
-		return "phrase"
-	default:
-		return "unknown"
-	}
-}
-
-// SetCredentialType sets the credential type for the role given its string form.
-// Returns an error if the given credential type string is unknown.
-func (c *Config) SetCredentialType(credentialType string) error {
-	switch credentialType {
-	case CredentialTypePassword.String():
-		c.CredentialType = CredentialTypePassword
-	case CredentialTypePhrase.String():
-		c.CredentialType = CredentialTypePhrase
-	default:
-		return fmt.Errorf("invalid credential_type %q", credentialType)
-	}
-	return nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -20,9 +20,11 @@ import (
 
 type Config struct {
 	*ldaputil.ConfigEntry
-	LastBindPassword         string    `json:"last_bind_password"`
-	LastBindPasswordRotation time.Time `json:"last_bind_password_rotation"`
-	Schema                   string    `json:"schema"`
+	// CredentialType specifies the type of credential to generate for the Schema
+	CredentialType           CredentialType `json:"credential_type"`
+	LastBindPassword         string         `json:"last_bind_password"`
+	LastBindPasswordRotation time.Time      `json:"last_bind_password_rotation"`
+	Schema                   string         `json:"schema"`
 }
 
 func New(logger hclog.Logger) Client {
@@ -275,4 +277,38 @@ func errorf(format string, wrappedErr error) error {
 	}
 
 	return fmt.Errorf(format, wrappedErr)
+}
+
+// CredentialType is a type of database credential.
+type CredentialType int
+
+const (
+	CredentialTypeUnknown CredentialType = iota
+	CredentialTypePassword
+	CredentialTypePhrase
+)
+
+func (c CredentialType) String() string {
+	switch c {
+	case CredentialTypePassword:
+		return "password"
+	case CredentialTypePhrase:
+		return "phrase"
+	default:
+		return "unknown"
+	}
+}
+
+// SetCredentialType sets the credential type for the role given its string form.
+// Returns an error if the given credential type string is unknown.
+func (c *Config) SetCredentialType(credentialType string) error {
+	switch credentialType {
+	case CredentialTypePassword.String():
+		c.CredentialType = CredentialTypePassword
+	case CredentialTypePhrase.String():
+		c.CredentialType = CredentialTypePhrase
+	default:
+		return fmt.Errorf("invalid credential_type %q", credentialType)
+	}
+	return nil
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -207,7 +207,6 @@ func TestUpdatePasswordRACF(t *testing.T) {
 					t.Fatalf("Expected field %s to exist in newValues", field.String())
 				}
 
-				t.Logf("JMF: expectedValues: %v, actualValues: %v", expectedValues, actualValues)
 				require.Equal(t, expectedValues, actualValues)
 			}
 

--- a/client/credential_type.go
+++ b/client/credential_type.go
@@ -9,7 +9,10 @@ type CredentialType int
 
 const (
 	CredentialTypeUnknown CredentialType = iota
+	// CredentialTypePassword is the default for all LDAP implementations
 	CredentialTypePassword
+	// CredentialTypePhrase is used for to customize the RACF schema to support
+	// password phrases
 	CredentialTypePhrase
 )
 

--- a/client/credential_type.go
+++ b/client/credential_type.go
@@ -1,0 +1,39 @@
+package client
+
+import "fmt"
+
+const DefaultCredentialType = CredentialType(CredentialTypePassword)
+
+// CredentialType is a custom type of LDAP credential.
+type CredentialType int
+
+const (
+	CredentialTypeUnknown CredentialType = iota
+	CredentialTypePassword
+	CredentialTypePhrase
+)
+
+func (c CredentialType) String() string {
+	switch c {
+	case CredentialTypePassword:
+		return "password"
+	case CredentialTypePhrase:
+		return "phrase"
+	default:
+		return "unknown"
+	}
+}
+
+// SetCredentialType sets the credential type for the LDAP config given its string form.
+// Returns an error if the given credential type string is unknown.
+func (c *Config) SetCredentialType(credentialType string) error {
+	switch credentialType {
+	case CredentialTypePassword.String():
+		c.CredentialType = CredentialTypePassword
+	case CredentialTypePhrase.String():
+		c.CredentialType = CredentialTypePhrase
+	default:
+		return fmt.Errorf("invalid credential_type %q", credentialType)
+	}
+	return nil
+}

--- a/client/schema.go
+++ b/client/schema.go
@@ -40,6 +40,9 @@ func GetSchemaFieldRegistry(cfg *Config, newPassword string) (map[*Field][]strin
 
 	case SchemaRACF:
 		fields := map[*Field][]string{}
+		// Password and password phrase management are mutually exclusive
+		// operations. When the system is configured to manage one, it will not
+		// modify the other.
 		if cfg.CredentialType == CredentialTypePhrase {
 			fields[FieldRegistry.RACFPassphrase] = []string{newPassword}
 		} else {

--- a/client_test.go
+++ b/client_test.go
@@ -64,7 +64,7 @@ func Test_UpdateDNPassword_AD_UserPrincipalName(t *testing.T) {
 	}
 
 	// depending on the schema, the password may be formatted, so we leverage this helper function
-	fields, err := client.GetSchemaFieldRegistry(config.Schema, newPassword)
+	fields, err := client.GetSchemaFieldRegistry(config, newPassword)
 	assert.NoError(t, err)
 	for k, v := range fields {
 		conn.ModifyRequestToExpect.Replace(k.String(), v)
@@ -108,7 +108,7 @@ func Test_UpdateDNPassword_AD_UserPrincipalName_Missing_upndomain(t *testing.T) 
 	}
 
 	// depending on the schema, the password may be formatted, so we leverage this helper function
-	fields, err := client.GetSchemaFieldRegistry(config.Schema, newPassword)
+	fields, err := client.GetSchemaFieldRegistry(config, newPassword)
 	assert.NoError(t, err)
 	for k, v := range fields {
 		conn.ModifyRequestToExpect.Replace(k.String(), v)
@@ -151,7 +151,7 @@ func Test_UpdateDNPassword_AD_DN(t *testing.T) {
 	}
 
 	// depending on the schema, the password may be formatted, so we leverage this helper function
-	fields, err := client.GetSchemaFieldRegistry(config.Schema, newPassword)
+	fields, err := client.GetSchemaFieldRegistry(config, newPassword)
 	assert.NoError(t, err)
 	for k, v := range fields {
 		conn.ModifyRequestToExpect.Replace(k.String(), v)

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package openldap
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/require"
+)
+
+func assertNoError(t *testing.T, resp *logical.Response, err error) {
+	t.Helper()
+	require.NoError(t, err)
+	require.Nil(t, resp.Error())
+}
+
+func pathOperation(t *testing.T, b *backend, s logical.Storage, path string, d map[string]interface{}, o logical.Operation) (*logical.Response, error) {
+	t.Helper()
+	req := &logical.Request{
+		Operation: o,
+		Path:      path,
+		Storage:   s,
+		Data:      d,
+	}
+
+	return b.HandleRequest(context.Background(), req)
+}
+
+func testCreateConfigWithData(t *testing.T, b *backend, s logical.Storage, d map[string]interface{}) (*logical.Response, error) {
+	t.Helper()
+	return pathOperation(t, b, s, configPath, d, logical.CreateOperation)
+}
+
+func testUpdateConfigWithData(t *testing.T, b *backend, s logical.Storage, d map[string]interface{}) (*logical.Response, error) {
+	t.Helper()
+	return pathOperation(t, b, s, configPath, d, logical.UpdateOperation)
+}
+
+func testReadConfig(t *testing.T, b *backend, s logical.Storage) (*logical.Response, error) {
+	t.Helper()
+	return pathOperation(t, b, s, configPath, nil, logical.ReadOperation)
+}
+
+func testDeleteConfig(t *testing.T, b *backend, s logical.Storage) (*logical.Response, error) {
+	t.Helper()
+	return pathOperation(t, b, s, configPath, nil, logical.DeleteOperation)
+}

--- a/path_config.go
+++ b/path_config.go
@@ -22,7 +22,7 @@ const (
 	configPath            = "config"
 	defaultPasswordLength = 64
 	defaultSchema         = client.SchemaOpenLDAP
-	defaultCredentialType = client.CredentialType(client.CredentialTypePassword)
+	defaultCredentialType = client.DefaultCredentialType
 	defaultTLSVersion     = "tls12"
 	defaultCtxTimeout     = 1 * time.Minute
 
@@ -333,6 +333,11 @@ func (b *backend) configReadOperation(ctx context.Context, req *logical.Request,
 		configMap["schema"] = config.LDAP.Schema
 	}
 	configMap["credential_type"] = config.LDAP.CredentialType.String()
+	if config.LDAP.CredentialType == client.CredentialTypeUnknown {
+		// this handles the upgrade path for legacy configs created before
+		// credential_type was added
+		configMap["credential_type"] = client.CredentialTypePassword.String()
+	}
 
 	config.PopulateAutomatedRotationData(configMap)
 

--- a/path_config.go
+++ b/path_config.go
@@ -22,7 +22,7 @@ const (
 	configPath            = "config"
 	defaultPasswordLength = 64
 	defaultSchema         = client.SchemaOpenLDAP
-	defaultCredentialType = CredentialType(CredentialTypePassword)
+	defaultCredentialType = client.CredentialType(client.CredentialTypePassword)
 	defaultTLSVersion     = "tls12"
 	defaultCtxTimeout     = 1 * time.Minute
 
@@ -205,7 +205,7 @@ func (b *backend) configCreateUpdateOperation(ctx context.Context, req *logical.
 	if credentialTypeRaw, ok := fieldData.GetOk("credential_type"); ok {
 		credentialType = credentialTypeRaw.(string)
 	}
-	if err := conf.setCredentialType(credentialType); err != nil {
+	if err := conf.LDAP.SetCredentialType(credentialType); err != nil {
 		return nil, err
 	}
 
@@ -332,7 +332,7 @@ func (b *backend) configReadOperation(ctx context.Context, req *logical.Request,
 	if config.LDAP.Schema != "" {
 		configMap["schema"] = config.LDAP.Schema
 	}
-	configMap["credential_type"] = config.CredentialType.String()
+	configMap["credential_type"] = config.LDAP.CredentialType.String()
 
 	config.PopulateAutomatedRotationData(configMap)
 
@@ -351,46 +351,11 @@ func (b *backend) configDeleteOperation(ctx context.Context, req *logical.Reques
 
 type config struct {
 	LDAP                         *client.Config
-	PasswordPolicy               string         `json:"password_policy,omitempty"`
-	SkipStaticRoleImportRotation bool           `json:"skip_static_role_import_rotation"`
-	CredentialType               CredentialType `json:"credential_type"`
+	PasswordPolicy               string `json:"password_policy,omitempty"`
+	SkipStaticRoleImportRotation bool   `json:"skip_static_role_import_rotation"`
 
 	automatedrotationutil.AutomatedRotationParams
 
 	// Deprecated
 	PasswordLength int `json:"length,omitempty"`
-}
-
-// CredentialType is a type of database credential.
-type CredentialType int
-
-const (
-	CredentialTypeUnknown CredentialType = iota
-	CredentialTypePassword
-	CredentialTypePhrase
-)
-
-func (c CredentialType) String() string {
-	switch c {
-	case CredentialTypePassword:
-		return "password"
-	case CredentialTypePhrase:
-		return "phrase"
-	default:
-		return "unknown"
-	}
-}
-
-// setCredentialType sets the credential type for the role given its string form.
-// Returns an error if the given credential type string is unknown.
-func (c *config) setCredentialType(credentialType string) error {
-	switch credentialType {
-	case CredentialTypePassword.String():
-		c.CredentialType = CredentialTypePassword
-	case CredentialTypePhrase.String():
-		c.CredentialType = CredentialTypePhrase
-	default:
-		return fmt.Errorf("invalid credential_type %q", credentialType)
-	}
-	return nil
 }

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -267,6 +267,22 @@ func TestConfig_Create(t *testing.T) {
 				),
 			},
 		},
+		"credential_type password": {
+			createData: fieldData(map[string]interface{}{
+				"binddn":          "tester",
+				"bindpass":        "pa$$w0rd",
+				"url":             "ldap://138.91.247.105",
+				"credential_type": client.CredentialTypePassword.String(),
+			}),
+			expectedReadResp: &logical.Response{
+				Data: ldapResponseData(
+					"binddn", "tester",
+					"url", "ldap://138.91.247.105",
+					"credential_type", client.CredentialTypePassword.String(),
+					"request_timeout", 90,
+				),
+			},
+		},
 		"credential_type phrase": {
 			createData: fieldData(map[string]interface{}{
 				"binddn":          "tester",


### PR DESCRIPTION
## Summary
This PR introduces a `credential_type` field to the /config endpoint, enabling support for RACF password phrases.

## Detailed Description

This pull request introduces a new, optional field `credential_type` to the /config endpoint of the Vault OpenLDAP secrets engine. This field allows administrators to explicitly choose the type of credentials that static roles will manage in the RACF backend. Your password policy must be configured to enforce your RACF system's policy. The `credential_type` field only ensures the `racfPassPhrase` schema field is used to modify the user's password.

The supported values for `credential_type` are:

- `password` (default): This option maintains the existing behavior of the secrets engine, where static roles manage traditional RACF passwords.

- `phrase`: When set to phrase, the secrets engine will modify the RACF schema for all static roles, instructing them to manage password phrases instead of passwords.

This implementation enforces that password and password phrase management are mutually exclusive operations within the secrets engine's configuration. When the system is configured to manage one type of credential, it will not attempt to modify or manage the other.

Example config
```
vault write ldap/config \
	url="ldap://localhost:1389" \
	binddn="RACFID=TEST,PROFILETYPE=USER,CN=RACFCN" \
	bindpass="secretpass" \
	password_policy="racf-password-policy" \
	credential_type="phrase" \
	schema=racf
```

# Related Issues/Pull Requests
- [ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
- [ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [ ] Backwards compatible

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
