### PR TITLE
Add terraform test bootstrap for RACF static roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,11 @@ tmp/
 
 scripts/custom.sh
 
+**/.terraform/*
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+
+# ldap racf terraform
+seed.ldif
+cleanup.ldif

--- a/.gitignore
+++ b/.gitignore
@@ -41,9 +41,6 @@ website/build
 .vagrant/
 Vagrantfile
 
-# Configs
-*.hcl
-
 .DS_Store
 .idea
 .vscode

--- a/bootstrap/terraform/README.md
+++ b/bootstrap/terraform/README.md
@@ -1,0 +1,36 @@
+# Terraform Bootstrap
+
+## RACF Test
+
+The `racf` directory contains terraform config to
+
+- create 10 users on your RACF LDAP server with password phrases
+- configure the openldap secrets engine to connect to your RACF server
+- create 10 static roles to manage the RACF user password phrases
+
+### Prerequisites
+
+- Vault server running with a `plugin_directory` configured
+- RACF LDAP Server
+- Modify `variables.tf` as necessary for your environment; in particular, `racf_bind_username`.
+
+### Setup
+Build, copy the plugin binary to the plugin dir, and register the plugin with Vault:
+```
+export PLUGIN_DIR=<your plugin dir path>
+export PLUGIN_PATH=racf
+make configure
+```
+
+Create the RACF users and configure the secrets engine:
+```
+cd bootstrap/terraform/racf/
+export TF_VAR_racf_bind_password=foobar
+terraform apply
+```
+
+### Teardown
+Cleanup the RACF users and Vault:
+```
+terraform destroy
+```

--- a/bootstrap/terraform/racf/main.tf
+++ b/bootstrap/terraform/racf/main.tf
@@ -1,0 +1,95 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+terraform {
+  required_providers {
+    vault = {
+      source  = "hashicorp/vault"
+      version = ">= 5.0.0"
+    }
+  }
+}
+
+provider "vault" {
+  address         = "http://127.0.0.1:8200"
+  skip_tls_verify = true
+}
+
+# This resource will run a script during the apply phase to create static RACF
+# users on your RACF server
+resource "null_resource" "racf_create_static_users" {
+  provisioner "local-exec" {
+    command = "./scripts/add_users.sh"
+
+    environment = {
+      BIND_DN       = var.racf_bind_username
+      BIND_PASSWORD = var.racf_bind_password
+      LDAP_URL      = var.racf_ldap_url
+      USER_DN       = var.racf_user_dn
+      GROUP         = var.racf_group
+    }
+  }
+}
+
+# This resource will run a cleanup script during the destroy phase to delete
+# static RACF users on your RACF server
+resource "null_resource" "racf_cleanup_static_users" {
+  # triggers are a workaround to be able to use tf vars
+  triggers = {
+    bind_dn       = var.racf_bind_username
+    bind_password = var.racf_bind_password
+    ldap_url      = var.racf_ldap_url
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "./scripts/delete_users.sh"
+
+    environment = {
+      BIND_DN       = self.triggers.bind_dn
+      BIND_PASSWORD = self.triggers.bind_password
+      LDAP_URL      = self.triggers.ldap_url
+    }
+  }
+}
+
+# Create the password policy to be RACF-compatible
+resource "vault_password_policy" "racf_policy" {
+  name   = "racf-policy"
+  policy = file("${path.module}/racf_password_policy.hcl")
+}
+
+# Mount the RACF secret engine
+resource "vault_mount" "openldap_racf" {
+  path        = "racf"
+  type        = "vault-plugin-secrets-openldap"
+  description = "RACF LDAP secrets engine"
+}
+
+# Configure the mounted secrets engine with credential_type "phrase"
+# We use vault_generic_secret because the native resource does not yet support
+# `credential_type`
+resource "vault_generic_secret" "racf_config" {
+  path = "${vault_mount.openldap_racf.path}/config"
+
+  data_json = jsonencode({
+    binddn          = var.racf_bind_username
+    bindpass        = var.racf_bind_password
+    url             = var.racf_ldap_url
+    userdn          = var.racf_user_dn
+    schema          = "racf"
+    credential_type = "phrase"
+    password_policy = vault_password_policy.racf_policy.name
+  })
+}
+
+# Create 10 static roles: user0...user9
+resource "vault_ldap_secret_backend_static_role" "racf_static_roles" {
+  depends_on = [vault_generic_secret.racf_config]
+  mount      = vault_mount.openldap_racf.path
+  count      = 10
+
+  username        = "USER${count.index}"
+  role_name       = "user${count.index}"
+  rotation_period = "60"
+}

--- a/bootstrap/terraform/racf/main.tf
+++ b/bootstrap/terraform/racf/main.tf
@@ -61,7 +61,8 @@ resource "vault_password_policy" "racf_policy" {
 
 # Mount the RACF secret engine
 resource "vault_mount" "openldap_racf" {
-  path        = "racf"
+  path = "racf"
+  # change type to "ldap" if you are using the builtin plugin
   type        = "vault-plugin-secrets-openldap"
   description = "RACF LDAP secrets engine"
 }
@@ -85,7 +86,7 @@ resource "vault_generic_secret" "racf_config" {
 
 # Create 10 static roles: user0...user9
 resource "vault_ldap_secret_backend_static_role" "racf_static_roles" {
-  depends_on = [vault_generic_secret.racf_config]
+  depends_on = [vault_generic_secret.racf_config, null_resource.racf_create_static_users]
   mount      = vault_mount.openldap_racf.path
   count      = 10
 

--- a/bootstrap/terraform/racf/outputs.tf
+++ b/bootstrap/terraform/racf/outputs.tf
@@ -1,0 +1,11 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+output "info" {
+  value = <<EOF
+
+You can SSH into the RACF system with one of the configured users:
+    ssh USER0@${trimprefix(var.racf_ldap_url, "ldap://")}
+
+EOF
+}

--- a/bootstrap/terraform/racf/racf_password_policy.hcl
+++ b/bootstrap/terraform/racf/racf_password_policy.hcl
@@ -1,0 +1,13 @@
+length = 25
+rule "charset" {
+  charset = "abcdefghijklmnopqrstuvwxyz"
+  min-chars = 1
+}
+rule "charset" {
+  charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  min-chars = 1
+}
+rule "charset" {
+  charset = "0123456789"
+  min-chars = 1
+}

--- a/bootstrap/terraform/racf/scripts/add_users.sh
+++ b/bootstrap/terraform/racf/scripts/add_users.sh
@@ -11,6 +11,9 @@ set -e
 [ "${USER_DN:?}" ]
 [ "${GROUP:?}" ]
 
+rm seed.ldif || true
+rm cleanup.ldif || true
+
 for i in $(seq 0 9); do
 
   USER="USER${i}"

--- a/bootstrap/terraform/racf/scripts/add_users.sh
+++ b/bootstrap/terraform/racf/scripts/add_users.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+# All of these environment variables are required or an error will be returned.
+[ "${BIND_DN:?}" ]
+[ "${BIND_PASSWORD:?}" ]
+[ "${LDAP_URL:?}" ]
+[ "${USER_DN:?}" ]
+[ "${GROUP:?}" ]
+
+for i in $(seq 0 9); do
+
+  USER="USER${i}"
+
+  # create the seed ldif
+  cat >> seed.ldif <<EOF
+dn: racfid=${USER},${USER_DN}
+objectClass: racfUser
+racfid: ${USER}
+racfPassPhrase: initialracfpassphrase1234
+racfdefaultgroup: ${GROUP}
+racfowner: ${GROUP}
+
+EOF
+
+  # create the cleanup ldif
+  cat >> cleanup.ldif <<EOF
+dn: racfid=${USER},${USER_DN}
+changetype: delete
+
+EOF
+
+done
+
+ldapadd -x -D "${BIND_DN}" -w "${BIND_PASSWORD}" \
+  -H "${LDAP_URL}" -f ./seed.ldif

--- a/bootstrap/terraform/racf/scripts/delete_users.sh
+++ b/bootstrap/terraform/racf/scripts/delete_users.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+# All of these environment variables are required or an error will be returned.
+[ "${BIND_DN:?}" ]
+[ "${BIND_PASSWORD:?}" ]
+[ "${LDAP_URL:?}" ]
+
+ldapmodify -x -D "${BIND_DN}" -w "${BIND_PASSWORD}" \
+  -H "${LDAP_URL}" -f ./cleanup.ldif
+
+rm seed.ldif
+rm cleanup.ldif
+

--- a/bootstrap/terraform/racf/scripts/delete_users.sh
+++ b/bootstrap/terraform/racf/scripts/delete_users.sh
@@ -12,6 +12,6 @@ set -e
 ldapmodify -x -D "${BIND_DN}" -w "${BIND_PASSWORD}" \
   -H "${LDAP_URL}" -f ./cleanup.ldif
 
-rm seed.ldif
-rm cleanup.ldif
+rm seed.ldif || true
+rm cleanup.ldif || true
 

--- a/bootstrap/terraform/racf/variables.tf
+++ b/bootstrap/terraform/racf/variables.tf
@@ -1,0 +1,36 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+variable "racf_bind_username" {
+  description = "The RACF bind distinguished name"
+  type        = string
+  default     = "RACFID=JMF,PROFILETYPE=USER,CN=RACFHC4"
+}
+
+variable "racf_user_dn" {
+  description = "The RACF base distinguished name for managed users"
+  type        = string
+  default     = "PROFILETYPE=USER,CN=RACFHC4"
+}
+
+# set this with:
+#   export TF_VAR_racf_bind_password=foobar
+variable "racf_bind_password" {
+  description = "The RACF bind password"
+  type        = string
+  sensitive   = true
+}
+
+# set this with:
+#   export TF_VAR_racf_ldap_url=ldap://test.com
+variable "racf_ldap_url" {
+  description = "The LDAP server URL"
+  type        = string
+}
+
+variable "racf_group" {
+  description = "The user's primary or default group"
+  type        = string
+  default     = "RACFID=SVTGRP,PROFILETYPE=GROUP,CN=RACFHC4"
+}
+

--- a/path_config.go
+++ b/path_config.go
@@ -356,46 +356,11 @@ func (b *backend) configDeleteOperation(ctx context.Context, req *logical.Reques
 
 type config struct {
 	LDAP                         *client.Config
-	PasswordPolicy               string         `json:"password_policy,omitempty"`
-	SkipStaticRoleImportRotation bool           `json:"skip_static_role_import_rotation"`
-	CredentialType               CredentialType `json:"credential_type"`
+	PasswordPolicy               string `json:"password_policy,omitempty"`
+	SkipStaticRoleImportRotation bool   `json:"skip_static_role_import_rotation"`
 
 	automatedrotationutil.AutomatedRotationParams
 
 	// Deprecated
 	PasswordLength int `json:"length,omitempty"`
-}
-
-// CredentialType is a type of database credential.
-type CredentialType int
-
-const (
-	CredentialTypeUnknown CredentialType = iota
-	CredentialTypePassword
-	CredentialTypePhrase
-)
-
-func (c CredentialType) String() string {
-	switch c {
-	case CredentialTypePassword:
-		return "password"
-	case CredentialTypePhrase:
-		return "phrase"
-	default:
-		return "unknown"
-	}
-}
-
-// setCredentialType sets the credential type for the role given its string form.
-// Returns an error if the given credential type string is unknown.
-func (c *config) setCredentialType(credentialType string) error {
-	switch credentialType {
-	case CredentialTypePassword.String():
-		c.CredentialType = CredentialTypePassword
-	case CredentialTypePhrase.String():
-		c.CredentialType = CredentialTypePhrase
-	default:
-		return fmt.Errorf("invalid credential_type %q", credentialType)
-	}
-	return nil
 }

--- a/path_config.go
+++ b/path_config.go
@@ -356,11 +356,46 @@ func (b *backend) configDeleteOperation(ctx context.Context, req *logical.Reques
 
 type config struct {
 	LDAP                         *client.Config
-	PasswordPolicy               string `json:"password_policy,omitempty"`
-	SkipStaticRoleImportRotation bool   `json:"skip_static_role_import_rotation"`
+	PasswordPolicy               string         `json:"password_policy,omitempty"`
+	SkipStaticRoleImportRotation bool           `json:"skip_static_role_import_rotation"`
+	CredentialType               CredentialType `json:"credential_type"`
 
 	automatedrotationutil.AutomatedRotationParams
 
 	// Deprecated
 	PasswordLength int `json:"length,omitempty"`
+}
+
+// CredentialType is a type of database credential.
+type CredentialType int
+
+const (
+	CredentialTypeUnknown CredentialType = iota
+	CredentialTypePassword
+	CredentialTypePhrase
+)
+
+func (c CredentialType) String() string {
+	switch c {
+	case CredentialTypePassword:
+		return "password"
+	case CredentialTypePhrase:
+		return "phrase"
+	default:
+		return "unknown"
+	}
+}
+
+// setCredentialType sets the credential type for the role given its string form.
+// Returns an error if the given credential type string is unknown.
+func (c *config) setCredentialType(credentialType string) error {
+	switch credentialType {
+	case CredentialTypePassword.String():
+		c.CredentialType = CredentialTypePassword
+	case CredentialTypePhrase.String():
+		c.CredentialType = CredentialTypePhrase
+	default:
+		return fmt.Errorf("invalid credential_type %q", credentialType)
+	}
+	return nil
 }


### PR DESCRIPTION
# Overview
This PR adds terraform config to bootstrap a testing environment. Followup to #184.

# Related Issues/Pull Requests
- [ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
- [ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [ ] Backwards compatible

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
