### PR TITLE
ci(workflow-permissions): scope GITHUB_TOKEN to least-privilege

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -3,6 +3,9 @@ on:
   push:
     paths:
     - '.github/workflows/**'
+permissions:
+  contents: read
+
 jobs:
   actionlint:
     # using `main` as the ref will keep your workflow up-to-date

--- a/.github/workflows/bulk-dep-upgrades.yaml
+++ b/.github/workflows/bulk-dep-upgrades.yaml
@@ -4,6 +4,11 @@ on:
   schedule:
     # Runs 12:00AM on the first of every month
     - cron: '0 0 1 * *'
+# Reusable bulk-dep workflow uses secrets.VAULT_ECO_GITHUB_TOKEN to open the
+# dependency PR; default GITHUB_TOKEN only needs read.
+permissions:
+  contents: read
+
 jobs:
   upgrade:
     # using `main` as the ref will keep your workflow up-to-date

--- a/.github/workflows/go-checks.yaml
+++ b/.github/workflows/go-checks.yaml
@@ -1,6 +1,9 @@
 name: Go checks
 on:
   push:
+permissions:
+  contents: read
+
 jobs:
   go-checks:
     # using `main` as the ref will keep your workflow up-to-date

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -6,6 +6,12 @@ on:
     types: [opened, closed, reopened]
   issue_comment: # Also triggers when commenting on a PR from the conversation view
     types: [created]
+# Reusable Jira sync only reads issue/PR metadata; writes go to Jira.
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
 jobs:
   sync:
     uses: hashicorp/vault-workflows-common/.github/workflows/jira.yaml@main

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,9 @@
 name: Run Tests
 on:
   push:
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     # using `main` as the ref will keep your workflow up-to-date


### PR DESCRIPTION
All five workflows here are callers for shared reusable workflows in `hashicorp/vault-workflows-common`. None of them needs the default `GITHUB_TOKEN` to have write scopes — the dependency-update PR is opened via `VAULT_ECO_GITHUB_TOKEN`, and the Jira mirror writes via `JIRA_SYNC_API_TOKEN`.

Each workflow now declares an explicit `permissions:` block:
- `actionlint.yaml`, `go-checks.yaml`, `tests.yaml` — `contents: read`
- `bulk-dep-upgrades.yaml` — `contents: read`
- `jira.yaml` — `contents: read` + `issues: read` + `pull-requests: read`

YAML validated locally with `yaml.safe_load`.