### PR TITLE
backport role-count and library-count API endpoints from ENT to CE

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -62,6 +62,9 @@ func Backend(client ldapClient) *backend {
 			b.pathSetCheckIn(),
 			b.pathSetCheckOut(),
 			b.pathSetStatus(),
+			b.pathLibraryCount(),
+			b.pathStaticRoleCount(),
+			b.pathDynamicRoleCount(),
 
 			// These paths are more generic than the above. They must be
 			// appended last.

--- a/path_dynamic_role_count.go
+++ b/path_dynamic_role_count.go
@@ -1,0 +1,66 @@
+// Copyright IBM Corp. 2020, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package openldap
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+const dynamicRoleCountPath = "role-count"
+
+func (b *backend) pathDynamicRoleCount() []*framework.Path {
+	return []*framework.Path{
+		{
+			Pattern: dynamicRoleCountPath,
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: operationPrefixLDAP,
+				OperationVerb:   "read",
+				OperationSuffix: "role-count",
+			},
+			Fields: map[string]*framework.FieldSchema{},
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback:    b.operationDynamicRoleCountRead,
+					Summary:     "Read the total count of dynamic roles",
+					Description: "Returns the current count of LDAP dynamic roles across all hierarchical paths.",
+				},
+			},
+			HelpSynopsis:    "Read the total count of dynamic roles",
+			HelpDescription: "This endpoint returns the current count of LDAP dynamic roles.",
+		},
+	}
+}
+
+func (b *backend) operationDynamicRoleCountRead(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	// Get the role count
+	count := 0
+	countFunc := func(roleName string) (bool, error) {
+		if strings.HasSuffix(roleName, "/") {
+			return false, nil
+		}
+		entry, err := retrieveDynamicRole(ctx, req.Storage, roleName)
+		if err != nil {
+			return false, err
+		}
+		entryExists := entry != nil
+		if entryExists {
+			count++
+		}
+		return entryExists, nil
+	}
+	err := walkStoragePath(ctx, req.Storage, dynamicRolePath, countFunc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to count dynamic roles: %w", err)
+	}
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"count": count,
+		},
+	}, nil
+}

--- a/path_dynamic_role_count_test.go
+++ b/path_dynamic_role_count_test.go
@@ -1,0 +1,196 @@
+// Copyright IBM Corp. 2020, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package openldap
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// read the dynamic role count from API endpoint
+func readDynamicRoleCount(t *testing.T, b logical.Backend, s logical.Storage) int {
+	t.Helper()
+	req := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      dynamicRoleCountPath,
+		Storage:   s,
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Data)
+
+	count, ok := resp.Data["count"].(int)
+	require.True(t, ok, "count should be an int")
+	return count
+}
+
+// Create a dynamic role with the given name
+// 'ViaAPI' for consistency with other helpers and clarity re 'createDynamicRoleWithData'
+func createDynamicRoleViaAPI(t *testing.T, b logical.Backend, s logical.Storage, name string) {
+	t.Helper()
+	req := &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      dynamicRolePath + name,
+		Storage:   s,
+		Data:      getTestDynamicRoleConfig(name),
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	if resp != nil && resp.IsError() {
+		t.Fatalf("failed to create dynamic role: %v", resp.Error())
+	}
+}
+
+// Delete a dynamic role with the given name
+// 'ViaAPI' for clarity re 'deleteDynamicRole' in dynamic_role.go
+func deleteDynamicRoleViaAPI(t *testing.T, b logical.Backend, s logical.Storage, name string) {
+	t.Helper()
+	req := &logical.Request{
+		Operation: logical.DeleteOperation,
+		Path:      dynamicRolePath + name,
+		Storage:   s,
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	if resp != nil && resp.IsError() {
+		t.Fatalf("failed to delete dynamic role: %v", resp.Error())
+	}
+}
+
+// Assert the dynamic role count is equal to the expected value
+func assertDynamicRoleCount(t *testing.T, b logical.Backend, s logical.Storage, expected int) {
+	t.Helper()
+	actual := readDynamicRoleCount(t, b, s)
+	require.Equal(t, expected, actual, "Dynamic role count mismatch")
+}
+
+// Update an existing dynamic role
+// 'ViaAPI' for clarity re 'updateDynamicRoleWithData'
+func updateDynamicRoleViaAPI(t *testing.T, b logical.Backend, s logical.Storage, name string) {
+	t.Helper()
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      dynamicRolePath + name,
+		Storage:   s,
+		Data:      getTestDynamicRoleConfig(name),
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	if resp != nil && resp.IsError() {
+		t.Fatalf("failed to update dynamic role: %v", resp.Error())
+	}
+}
+
+func TestDynamicRoleCount(t *testing.T) {
+	ctx := context.Background()
+	b, s := getBackend(false)
+	defer b.Cleanup(ctx)
+	configureBackend(t, b, s)
+
+	t.Run("initial state", func(t *testing.T) {
+		assertDynamicRoleCount(t, b, s, 0)
+
+	})
+	t.Run("count after create", func(t *testing.T) {
+		createDynamicRoleViaAPI(t, b, s, "role1")
+		assertDynamicRoleCount(t, b, s, 1)
+		createDynamicRoleViaAPI(t, b, s, "role2")
+		assertDynamicRoleCount(t, b, s, 2)
+	})
+	t.Run("count after delete", func(t *testing.T) {
+		deleteDynamicRoleViaAPI(t, b, s, "role1")
+		assertDynamicRoleCount(t, b, s, 1)
+	})
+	t.Run("update does not change count", func(t *testing.T) {
+		updateDynamicRoleViaAPI(t, b, s, "role2")
+		assertDynamicRoleCount(t, b, s, 1)
+	})
+}
+
+func TestDynamicRoleCount_Hierarchical(t *testing.T) {
+	ctx := context.Background()
+	b, s := getBackend(false)
+	defer b.Cleanup(ctx)
+	configureBackend(t, b, s)
+
+	t.Run("create nested paths", func(t *testing.T) {
+		createDynamicRoleViaAPI(t, b, s, "foo")
+		assertDynamicRoleCount(t, b, s, 1)
+		createDynamicRoleViaAPI(t, b, s, "org/secure")
+		assertDynamicRoleCount(t, b, s, 2)
+		createDynamicRoleViaAPI(t, b, s, "org/platform/dev")
+		assertDynamicRoleCount(t, b, s, 3)
+	})
+	t.Run("delete nested paths", func(t *testing.T) {
+		deleteDynamicRoleViaAPI(t, b, s, "org/platform/dev")
+		assertDynamicRoleCount(t, b, s, 2)
+		deleteDynamicRoleViaAPI(t, b, s, "org/secure")
+		assertDynamicRoleCount(t, b, s, 1)
+		deleteDynamicRoleViaAPI(t, b, s, "foo")
+		assertDynamicRoleCount(t, b, s, 0)
+	})
+}
+
+func TestDynamicRoleCount_MixedOperations(t *testing.T) {
+	ctx := context.Background()
+	b, s := getBackend(false)
+	defer b.Cleanup(ctx)
+	configureBackend(t, b, s)
+
+	assertDynamicRoleCount(t, b, s, 0)
+	for i := 1; i <= 5; i++ {
+		createDynamicRoleViaAPI(t, b, s, fmt.Sprintf("role%d", i))
+	}
+	assertDynamicRoleCount(t, b, s, 5)
+	deleteDynamicRoleViaAPI(t, b, s, "role2")
+	deleteDynamicRoleViaAPI(t, b, s, "role4")
+	assertDynamicRoleCount(t, b, s, 3)
+	createDynamicRoleViaAPI(t, b, s, "org/role6")
+	assertDynamicRoleCount(t, b, s, 4)
+	deleteDynamicRoleViaAPI(t, b, s, "role1")
+	deleteDynamicRoleViaAPI(t, b, s, "role3")
+	deleteDynamicRoleViaAPI(t, b, s, "role5")
+	deleteDynamicRoleViaAPI(t, b, s, "org/role6")
+	assertDynamicRoleCount(t, b, s, 0)
+}
+
+func TestDynamicRoleCount_StorageError(t *testing.T) {
+	ctx := context.Background()
+	b := Backend(&fakeLdapClient{})
+	storage := new(mockStorage)
+	storage.On("List", mock.Anything, dynamicRolePath).Return([]string{}, fmt.Errorf("storage failure"))
+
+	req := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      dynamicRoleCountPath,
+		Storage:   storage,
+	}
+	resp, err := b.operationDynamicRoleCountRead(ctx, req, nil)
+	require.Nil(t, resp)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to count dynamic roles")
+}
+
+func TestDynamicRoleCount_SetAndDirectoryPrefixHaveSameNames(t *testing.T) {
+	ctx := context.Background()
+	b, s := getBackend(false)
+	defer b.Cleanup(ctx)
+	configureBackend(t, b, s)
+
+	createDynamicRoleViaAPI(t, b, s, "org")
+	assertDynamicRoleCount(t, b, s, 1)
+	createDynamicRoleViaAPI(t, b, s, "org/team1")
+	assertDynamicRoleCount(t, b, s, 2)
+	deleteDynamicRoleViaAPI(t, b, s, "org")
+	assertDynamicRoleCount(t, b, s, 1)
+	deleteDynamicRoleViaAPI(t, b, s, "org/team1")
+	assertDynamicRoleCount(t, b, s, 0)
+
+}

--- a/path_library_count.go
+++ b/path_library_count.go
@@ -1,0 +1,65 @@
+// Copyright IBM Corp. 2020, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package openldap
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+const libraryCountPath = "library-count"
+
+func (b *backend) pathLibraryCount() []*framework.Path {
+	return []*framework.Path{
+		{
+			Pattern: libraryCountPath,
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: operationPrefixLDAPLibrary,
+				OperationVerb:   "read",
+				OperationSuffix: "count",
+			},
+			Fields: map[string]*framework.FieldSchema{},
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback:    b.operationLibraryCountRead,
+					Summary:     "Read the total count of library sets",
+					Description: "Returns the current count of LDAP service account library sets across all hierarchical paths.",
+				},
+			},
+			HelpSynopsis:    "Read the total count of library sets",
+			HelpDescription: "This endpoint returns the current count of LDAP service account library sets.",
+		},
+	}
+}
+func (b *backend) operationLibraryCountRead(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	// Get the library set count
+	count := 0
+	countFunc := func(setName string) (bool, error) {
+		if strings.HasSuffix(setName, "/") {
+			return false, nil
+		}
+		entry, err := readSet(ctx, req.Storage, setName)
+		if err != nil {
+			return false, err
+		}
+		entryExists := entry != nil
+		if entryExists {
+			count++
+		}
+		return entryExists, nil
+	}
+	err := walkStoragePath(ctx, req.Storage, libraryPrefix, countFunc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to count library sets: %w", err)
+	}
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"count": count,
+		},
+	}, nil
+}

--- a/path_library_count_test.go
+++ b/path_library_count_test.go
@@ -1,0 +1,238 @@
+// Copyright IBM Corp. 2020, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package openldap
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// Read the library count from API endpoint
+func readLibraryCount(t *testing.T, b logical.Backend, s logical.Storage) int {
+	t.Helper()
+	req := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      libraryCountPath,
+		Storage:   s,
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Data)
+
+	count, ok := resp.Data["count"].(int)
+	require.True(t, ok, "count should be an int")
+
+	return count
+}
+
+// Create a library with the given name and service accounts
+func createLibrary(t *testing.T, b logical.Backend, s logical.Storage, name string, serviceAccounts []string) {
+	t.Helper()
+	req := &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      libraryPrefix + name,
+		Storage:   s,
+		Data: map[string]interface{}{
+			"service_account_names": serviceAccounts,
+			"ttl":                   "10h",
+			"max_ttl":               "11h",
+		},
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	if resp != nil && resp.IsError() {
+		t.Fatalf("failed to create library: %v", resp.Error())
+	}
+}
+
+// Delete a library with the given name
+func deleteLibrary(t *testing.T, b logical.Backend, s logical.Storage, name string) {
+	t.Helper()
+	req := &logical.Request{
+		Operation: logical.DeleteOperation,
+		Path:      libraryPrefix + name,
+		Storage:   s,
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	if resp != nil && resp.IsError() {
+		t.Fatalf("failed to delete library: %v", resp.Error())
+	}
+}
+
+// Assert that the library count is equal to the expected value
+func assertLibraryCount(t *testing.T, b logical.Backend, s logical.Storage, expected int) {
+	t.Helper()
+	actual := readLibraryCount(t, b, s)
+	require.Equal(t, expected, actual, "Library count mismatch")
+}
+
+// Update an existing library
+func updateLibrary(t *testing.T, b logical.Backend, s logical.Storage, name string, serviceAccounts []string) {
+	t.Helper()
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      libraryPrefix + name,
+		Storage:   s,
+		Data: map[string]interface{}{
+			"service_account_names": serviceAccounts,
+			"ttl":                   "9h",
+		},
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	if resp != nil && resp.IsError() {
+		t.Fatalf("failed to update library: %v", resp.Error())
+	}
+}
+
+// Configure the LDAP backend with test settings
+func configureBackend(t *testing.T, b logical.Backend, s logical.Storage) {
+	t.Helper()
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      configPath,
+		Storage:   s,
+		Data: map[string]interface{}{
+			"binddn":   "euclid",
+			"password": "password",
+			"url":      "ldap://ldap.forumsys.com:389",
+			"userdn":   "cn=read-only-admin, dc=example,dc=com",
+		},
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	if resp != nil && resp.IsError() {
+		t.Fatalf("failed to configure LDAP backend: %v", resp.Error())
+	}
+}
+
+func TestLibraryCount(t *testing.T) {
+	ctx := context.Background()
+	b, s := getBackend(false)
+	defer b.Cleanup(ctx)
+	configureBackend(t, b, s)
+
+	t.Run("initial state", func(t *testing.T) {
+		assertLibraryCount(t, b, s, 0)
+	})
+	t.Run("count after create", func(t *testing.T) {
+		createLibrary(t, b, s, "accounting-team", []string{"acct1", "acct2"})
+		assertLibraryCount(t, b, s, 1)
+		createLibrary(t, b, s, "dev-team", []string{"dev1", "dev2"})
+		assertLibraryCount(t, b, s, 2)
+	})
+
+	t.Run("count after delete", func(t *testing.T) {
+		deleteLibrary(t, b, s, "accounting-team")
+		assertLibraryCount(t, b, s, 1)
+	})
+
+	t.Run("update does not change count", func(t *testing.T) {
+		updateLibrary(t, b, s, "dev-team", []string{"dev1", "dev2", "dev3"})
+		assertLibraryCount(t, b, s, 1)
+	})
+}
+
+func TestLibraryCount_Hierarchical(t *testing.T) {
+	ctx := context.Background()
+	b, s := getBackend(false)
+	defer b.Cleanup(ctx)
+	configureBackend(t, b, s)
+
+	t.Run("create nested paths", func(t *testing.T) {
+		createLibrary(t, b, s, "foo", []string{"user1"})
+		assertLibraryCount(t, b, s, 1)
+		createLibrary(t, b, s, "org/secure", []string{"user2"})
+		assertLibraryCount(t, b, s, 2)
+		createLibrary(t, b, s, "org/platform/dev", []string{"user3"})
+		assertLibraryCount(t, b, s, 3)
+		createLibrary(t, b, s, "org/platform/prod/api", []string{"user4"})
+		assertLibraryCount(t, b, s, 4)
+	})
+	t.Run("delete nested paths", func(t *testing.T) {
+		deleteLibrary(t, b, s, "org/platform/prod/api")
+		assertLibraryCount(t, b, s, 3)
+		deleteLibrary(t, b, s, "org/platform/dev")
+		assertLibraryCount(t, b, s, 2)
+		deleteLibrary(t, b, s, "foo")
+		assertLibraryCount(t, b, s, 1)
+	})
+}
+
+func TestLibraryCount_MixedOperations(t *testing.T) {
+	ctx := context.Background()
+	b, s := getBackend(false)
+	defer b.Cleanup(ctx)
+	configureBackend(t, b, s)
+
+	assertLibraryCount(t, b, s, 0)
+	for i := 1; i <= 5; i++ {
+		createLibrary(t, b, s, fmt.Sprintf("lib%d", i), []string{fmt.Sprintf("user%d", i)})
+	}
+	assertLibraryCount(t, b, s, 5)
+
+	updateLibrary(t, b, s, "lib1", []string{"user1", "user1b"})
+	updateLibrary(t, b, s, "lib3", []string{"user3", "user3b"})
+	assertLibraryCount(t, b, s, 5)
+
+	deleteLibrary(t, b, s, "lib2")
+	deleteLibrary(t, b, s, "lib4")
+	assertLibraryCount(t, b, s, 3)
+
+	createLibrary(t, b, s, "lib6", []string{"user6"})
+	createLibrary(t, b, s, "lib7", []string{"user7"})
+	createLibrary(t, b, s, "org/lib8", []string{"user8"})
+	assertLibraryCount(t, b, s, 6)
+
+	updateLibrary(t, b, s, "lib5", []string{"user5-updated"})
+	assertLibraryCount(t, b, s, 6)
+
+	deleteLibrary(t, b, s, "lib1")
+	deleteLibrary(t, b, s, "lib3")
+	deleteLibrary(t, b, s, "lib5")
+	deleteLibrary(t, b, s, "lib6")
+	deleteLibrary(t, b, s, "lib7")
+	deleteLibrary(t, b, s, "org/lib8")
+	assertLibraryCount(t, b, s, 0)
+}
+
+func TestLibraryCount_StorageError(t *testing.T) {
+	ctx := context.Background()
+	b := Backend(&fakeLdapClient{})
+	storage := new(mockStorage)
+	storage.On("List", mock.Anything, libraryPrefix).Return([]string{}, fmt.Errorf("storage failure"))
+
+	req := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      libraryCountPath,
+		Storage:   storage,
+	}
+	resp, err := b.operationLibraryCountRead(ctx, req, nil)
+	require.Nil(t, resp)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to count library sets")
+}
+
+func TestLibraryCount_SetAndDirectoryPrefixHaveSameName(t *testing.T) {
+	ctx := context.Background()
+	b, s := getBackend(false)
+	defer b.Cleanup(ctx)
+	configureBackend(t, b, s)
+
+	createLibrary(t, b, s, "org", []string{"user1"})
+	assertLibraryCount(t, b, s, 1)
+	createLibrary(t, b, s, "org/team", []string{"user2"})
+	assertLibraryCount(t, b, s, 2)
+	deleteLibrary(t, b, s, "org")
+	assertLibraryCount(t, b, s, 1)
+	deleteLibrary(t, b, s, "org/team")
+	assertLibraryCount(t, b, s, 0)
+}

--- a/path_static_role_count.go
+++ b/path_static_role_count.go
@@ -1,0 +1,66 @@
+// Copyright IBM Corp. 2020, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package openldap
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+const staticRoleCountPath = "static-role-count"
+
+func (b *backend) pathStaticRoleCount() []*framework.Path {
+	return []*framework.Path{
+		{
+			Pattern: staticRoleCountPath,
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: operationPrefixLDAP,
+				OperationVerb:   "read",
+				OperationSuffix: "static-role-count",
+			},
+			Fields: map[string]*framework.FieldSchema{},
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback:    b.operationStaticRoleCountRead,
+					Summary:     "Read the total count of static roles",
+					Description: "Returns the current count of LDAP static roles across all hierarchical paths.",
+				},
+			},
+			HelpSynopsis:    "Read the total count of static roles",
+			HelpDescription: "This endpoint returns the current count of LDAP static roles",
+		},
+	}
+}
+
+func (b *backend) operationStaticRoleCountRead(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	// Get the static role count
+	count := 0
+	countFunc := func(roleName string) (bool, error) {
+		if strings.HasSuffix(roleName, "/") {
+			return false, nil
+		}
+		entry, err := b.staticRole(ctx, req.Storage, roleName)
+		if err != nil {
+			return false, err
+		}
+		entryExists := entry != nil
+		if entryExists {
+			count++
+		}
+		return entryExists, nil
+	}
+	err := walkStoragePath(ctx, req.Storage, staticRolePath, countFunc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to count static roles: %w", err)
+	}
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"count": count,
+		},
+	}, nil
+}

--- a/path_static_role_count_test.go
+++ b/path_static_role_count_test.go
@@ -84,7 +84,6 @@ func updateStaticRoleViaAPI(t *testing.T, b logical.Backend, s logical.Storage, 
 		Path:      staticRolePath + name,
 		Storage:   s,
 		Data: map[string]interface{}{
-			"username":        name,
 			"rotation_period": "48h",
 		},
 	}

--- a/path_static_role_count_test.go
+++ b/path_static_role_count_test.go
@@ -1,0 +1,201 @@
+// Copyright IBM Corp. 2020, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package openldap
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// Read the static role count from API endpoint
+func readStaticRoleCount(t *testing.T, b logical.Backend, s logical.Storage) int {
+	t.Helper()
+	req := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      staticRoleCountPath,
+		Storage:   s,
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Data)
+
+	count, ok := resp.Data["count"].(int)
+	require.True(t, ok, "count should be an int")
+	return count
+}
+
+// Create a static role with the given name
+// 'ViaAPI' for consistency with other helpers and clarity re 'createStaticRoleWithData'
+func createStaticRoleViaAPI(t *testing.T, b logical.Backend, s logical.Storage, name string) {
+	t.Helper()
+	req := &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      staticRolePath + name,
+		Storage:   s,
+		Data: map[string]interface{}{
+			"username":             name,
+			"rotation_period":      "24h",
+			"skip_import_rotation": true,
+		},
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	if resp != nil && resp.IsError() {
+		t.Fatalf("failed to create static role: %v", resp.Error())
+	}
+}
+
+// Delete a static role with the given name
+// 'ViaAPI' for clarity re 'deleteStaticRoleWithData'
+func deleteStaticRoleViaAPI(t *testing.T, b logical.Backend, s logical.Storage, name string) {
+	t.Helper()
+	req := &logical.Request{
+		Operation: logical.DeleteOperation,
+		Path:      staticRolePath + name,
+		Storage:   s,
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	if resp != nil && resp.IsError() {
+		t.Fatalf("failed to delete static role: %v", resp.Error())
+	}
+}
+
+// Assert the static role count is equal to the expected value
+func assertStaticRoleCount(t *testing.T, b logical.Backend, s logical.Storage, expected int) {
+	t.Helper()
+	actual := readStaticRoleCount(t, b, s)
+	require.Equal(t, expected, actual, "Static role count mismatch")
+}
+
+// Update an existing static role
+// 'ViaAPI' for clarity re 'updateStaticRoleWithData'
+func updateStaticRoleViaAPI(t *testing.T, b logical.Backend, s logical.Storage, name string) {
+	t.Helper()
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      staticRolePath + name,
+		Storage:   s,
+		Data: map[string]interface{}{
+			"username":        name,
+			"rotation_period": "48h",
+		},
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	if resp != nil && resp.IsError() {
+		t.Fatalf("failed to update static role: %v", resp.Error())
+	}
+}
+
+func TestStaticRoleCount(t *testing.T) {
+	ctx := context.Background()
+	b, s := getBackend(false)
+	defer b.Cleanup(ctx)
+	configureBackend(t, b, s)
+
+	t.Run("initial state", func(t *testing.T) {
+		assertStaticRoleCount(t, b, s, 0)
+	})
+	t.Run("count after create", func(t *testing.T) {
+		createStaticRoleViaAPI(t, b, s, "role1")
+		assertStaticRoleCount(t, b, s, 1)
+		createStaticRoleViaAPI(t, b, s, "role2")
+		assertStaticRoleCount(t, b, s, 2)
+	})
+	t.Run("count after delete", func(t *testing.T) {
+		deleteStaticRoleViaAPI(t, b, s, "role1")
+		assertStaticRoleCount(t, b, s, 1)
+	})
+	t.Run("update does not change count", func(t *testing.T) {
+		updateStaticRoleViaAPI(t, b, s, "role2")
+		assertStaticRoleCount(t, b, s, 1)
+	})
+}
+
+func TestStaticRoleCount_Hierarchical(t *testing.T) {
+	ctx := context.Background()
+	b, s := getBackend(false)
+	defer b.Cleanup(ctx)
+	configureBackend(t, b, s)
+
+	t.Run("create nested paths", func(t *testing.T) {
+		createStaticRoleViaAPI(t, b, s, "foo")
+		assertStaticRoleCount(t, b, s, 1)
+		createStaticRoleViaAPI(t, b, s, "org/secure")
+		assertStaticRoleCount(t, b, s, 2)
+		createStaticRoleViaAPI(t, b, s, "org/platform/dev")
+		assertStaticRoleCount(t, b, s, 3)
+	})
+	t.Run("delete nested paths", func(t *testing.T) {
+		deleteStaticRoleViaAPI(t, b, s, "org/platform/dev")
+		assertStaticRoleCount(t, b, s, 2)
+		deleteStaticRoleViaAPI(t, b, s, "org/secure")
+		assertStaticRoleCount(t, b, s, 1)
+		deleteStaticRoleViaAPI(t, b, s, "foo")
+		assertStaticRoleCount(t, b, s, 0)
+	})
+}
+
+func TestStaticRoleCount_MixedOperations(t *testing.T) {
+	ctx := context.Background()
+	b, s := getBackend(false)
+	defer b.Cleanup(ctx)
+	configureBackend(t, b, s)
+
+	assertStaticRoleCount(t, b, s, 0)
+	for i := 1; i <= 5; i++ {
+		createStaticRoleViaAPI(t, b, s, fmt.Sprintf("role%d", i))
+	}
+	assertStaticRoleCount(t, b, s, 5)
+	deleteStaticRoleViaAPI(t, b, s, "role2")
+	deleteStaticRoleViaAPI(t, b, s, "role4")
+	assertStaticRoleCount(t, b, s, 3)
+	createStaticRoleViaAPI(t, b, s, "org/role6")
+	assertStaticRoleCount(t, b, s, 4)
+	deleteStaticRoleViaAPI(t, b, s, "role1")
+	deleteStaticRoleViaAPI(t, b, s, "role3")
+	deleteStaticRoleViaAPI(t, b, s, "role5")
+	deleteStaticRoleViaAPI(t, b, s, "org/role6")
+	assertStaticRoleCount(t, b, s, 0)
+}
+
+func TestStaticRoleCount_StorageError(t *testing.T) {
+	ctx := context.Background()
+	b := Backend(&fakeLdapClient{})
+	storage := new(mockStorage)
+	storage.On("List", mock.Anything, staticRolePath).Return([]string{}, fmt.Errorf("storage failure"))
+
+	req := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      staticRoleCountPath,
+		Storage:   storage,
+	}
+	resp, err := b.operationStaticRoleCountRead(ctx, req, nil)
+	require.Nil(t, resp)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to count static roles")
+}
+
+func TestStaticRoleCount_SetAndDirectoryPrefixHaveSameName(t *testing.T) {
+	ctx := context.Background()
+	b, s := getBackend(false)
+	defer b.Cleanup(ctx)
+	configureBackend(t, b, s)
+
+	createStaticRoleViaAPI(t, b, s, "org")
+	assertStaticRoleCount(t, b, s, 1)
+	createStaticRoleViaAPI(t, b, s, "org/team")
+	assertStaticRoleCount(t, b, s, 2)
+	deleteStaticRoleViaAPI(t, b, s, "org")
+	assertStaticRoleCount(t, b, s, 1)
+	deleteStaticRoleViaAPI(t, b, s, "org/team")
+	assertStaticRoleCount(t, b, s, 0)
+}


### PR DESCRIPTION
# Overview
Backport library count and role count endpoints to the `main` branch

# Related Issues/Pull Requests
- [ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
- [ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [ ] Backwards compatible

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
